### PR TITLE
feat(web): share-prayer modal, landing polish, transparent scrollbar

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,6 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
+    "@tanstack/react-query": "^5.101.0",
+    "axios": "^1.17.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",
@@ -16,7 +19,10 @@
     "next": "16.2.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "tailwind-merge": "^3.6.0"
+    "react-hook-form": "^7.77.0",
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.4.3",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -75,7 +75,18 @@
   }
 
   html {
-    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--color-royal) 40%, transparent) transparent;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
+  }
+
+  section[id] {
+    scroll-margin-top: 6rem;
   }
 
   html,
@@ -95,15 +106,18 @@
   }
 
   ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: 6px;
+    height: 6px;
   }
   ::-webkit-scrollbar-track {
     background: transparent;
   }
   ::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--color-royal) 60%, transparent);
+    background: color-mix(in srgb, var(--color-royal) 40%, transparent);
     border-radius: 999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--color-royal) 65%, transparent);
   }
 }
 

--- a/apps/web/src/features/landing/LandingPage.tsx
+++ b/apps/web/src/features/landing/LandingPage.tsx
@@ -7,6 +7,7 @@ import { RewardSection } from "./components/RewardSection";
 import { ShareSection } from "./components/ShareSection";
 import { SiteFooter } from "./components/SiteFooter";
 import { SiteNav } from "./components/SiteNav";
+import { ShareModal } from "@/features/share/components/ShareModal";
 
 export const LandingPage = () => (
   <>
@@ -21,5 +22,6 @@ export const LandingPage = () => (
       <ShareSection />
     </main>
     <SiteFooter />
+    <ShareModal />
   </>
 );

--- a/apps/web/src/features/landing/components/AboutSection.tsx
+++ b/apps/web/src/features/landing/components/AboutSection.tsx
@@ -1,6 +1,7 @@
 import { ghafirVerse } from "../data/prayer";
 import { BracePrayer } from "./BracePrayer";
 import { Reveal } from "./Reveal";
+import { SectionHeading } from "./SectionHeading";
 
 const paragraphs = [
   "ادْعُونِي مبادرة خيرية مفتوحة المصدر، تهدف إلى تذكير الناس بالدعاء وذكر الله. بدأت بفكرة بسيطة وجميلة: أن يصلك دعاء كل يوم عبر منصّاتك المفضلة.",
@@ -8,16 +9,9 @@ const paragraphs = [
 ];
 
 export const AboutSection = () => (
-  <section id="about" className="bg-paper px-6 py-28 md:py-36">
+  <section id="about" className="bg-paper px-6 py-20 md:py-28">
     <div className="mx-auto max-w-6xl">
-      <Reveal>
-        <div className="mb-16 flex flex-col items-center gap-3 text-center">
-          <span className="text-sm tracking-[0.18em] text-violet">عن المبادرة</span>
-          <h2 className="font-display text-4xl text-royal md:text-5xl">
-            عن ادْعُونِي
-          </h2>
-        </div>
-      </Reveal>
+      <SectionHeading label="عن المبادرة" title="عن ادْعُونِي" />
 
       <div className="grid items-stretch gap-8 lg:grid-cols-2">
         <Reveal>

--- a/apps/web/src/features/landing/components/CommunityPrayersSection.tsx
+++ b/apps/web/src/features/landing/components/CommunityPrayersSection.tsx
@@ -1,10 +1,10 @@
-import { buttonVariants } from "@/shared/ui/button";
+import { ShareButton } from "@/features/share/components/ShareButton";
 import { PrayerMarquee } from "./PrayerMarquee";
 import { Reveal } from "./Reveal";
 import { SectionHeading } from "./SectionHeading";
 
 export const CommunityPrayersSection = () => (
-  <section id="prayers" className="overflow-hidden bg-paper py-28 md:py-36">
+  <section id="prayers" className="overflow-hidden bg-paper py-20 md:py-28">
     <div className="mx-auto max-w-6xl px-6">
       <SectionHeading
         label="من أدعيتكم"
@@ -17,13 +17,10 @@ export const CommunityPrayersSection = () => (
       <PrayerMarquee />
     </Reveal>
 
-    <div className="mx-auto mt-16 flex max-w-6xl justify-center px-6">
-      <a
-        href="#share"
-        className={buttonVariants({ variant: "default", size: "lg" })}
-      >
+    <div className="mx-auto mt-12 flex max-w-6xl justify-center px-6 md:mt-16">
+      <ShareButton variant="default" size="lg">
         شارك دعاءك أنت أيضًا
-      </a>
+      </ShareButton>
     </div>
   </section>
 );

--- a/apps/web/src/features/landing/components/HowItWorksSection.tsx
+++ b/apps/web/src/features/landing/components/HowItWorksSection.tsx
@@ -5,7 +5,7 @@ import { Reveal } from "./Reveal";
 import { SectionHeading } from "./SectionHeading";
 
 export const HowItWorksSection = () => (
-  <section id="how" className="bg-muted/40 px-6 py-28 md:py-36">
+  <section id="how" className="bg-muted/40 px-6 py-20 md:py-28">
     <div className="mx-auto max-w-6xl">
       <SectionHeading label="كيف تعمل" title="ثلاث خطوات بسيطة" />
 

--- a/apps/web/src/features/landing/components/MobileMenu.tsx
+++ b/apps/web/src/features/landing/components/MobileMenu.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { motion, useReducedMotion, type Variants } from "motion/react";
 import { useLockBodyScroll } from "@/shared/hooks/useLockBodyScroll";
 import { toArabicIndex } from "@/shared/lib/arabic";
-import { buttonVariants } from "@/shared/ui/button";
+import { ShareButton } from "@/features/share/components/ShareButton";
 import { navLinks } from "../data/navigation";
 import { platforms } from "../data/platforms";
 
@@ -81,13 +81,9 @@ export const MobileMenu = ({ onClose }: MobileMenuProps) => {
         animate="visible"
         className="flex flex-col gap-8"
       >
-        <a
-          href="#share"
-          onClick={onClose}
-          className={buttonVariants({ variant: "paper", size: "lg", className: "w-full" })}
-        >
+        <ShareButton variant="paper" size="lg" className="w-full" onClick={onClose}>
           شاركنا دعاءك
-        </a>
+        </ShareButton>
         <div className="flex items-center gap-6 text-paper/60">
           {livePlatforms.map((platform) => {
             const Icon = platform.icon;

--- a/apps/web/src/features/landing/components/PlatformPreview.tsx
+++ b/apps/web/src/features/landing/components/PlatformPreview.tsx
@@ -47,11 +47,13 @@ const DiscordFrame = () => (
 
 const WebFrame = () => (
   <div className="overflow-hidden rounded-2xl border border-border bg-paper">
-    <div dir="ltr" className="flex items-center gap-1.5 border-b border-border px-4 py-3">
-      <span className="size-2.5 rounded-full bg-neutral/25" />
-      <span className="size-2.5 rounded-full bg-neutral/25" />
-      <span className="size-2.5 rounded-full bg-neutral/25" />
-      <span className="ms-3 rounded-md bg-muted px-3 py-1 font-mono text-xs text-neutral">
+    <div dir="ltr" className="relative flex items-center border-b border-border px-4 py-3">
+      <div className="flex items-center gap-1.5">
+        <span className="size-2.5 rounded-full bg-neutral/25" />
+        <span className="size-2.5 rounded-full bg-neutral/25" />
+        <span className="size-2.5 rounded-full bg-neutral/25" />
+      </div>
+      <span className="absolute left-1/2 -translate-x-1/2 rounded-md bg-muted px-3 py-1 font-mono text-xs text-neutral">
         ad3oni.com
       </span>
     </div>
@@ -73,7 +75,7 @@ const NotificationFrame = ({ platform }: { platform: Platform }) => {
         <div className="flex-1">
           <div className="flex items-center justify-between">
             <p className="font-display text-sm text-royal">ادْعُونِي</p>
-            <span className="font-mono text-[10px] text-neutral">الآن</span>
+            <span className="font-sans text-[10px] text-neutral">الآن</span>
           </div>
           <p className="text-xs text-neutral">حان وقت دعاء اليوم</p>
         </div>

--- a/apps/web/src/features/landing/components/PlatformTabs.tsx
+++ b/apps/web/src/features/landing/components/PlatformTabs.tsx
@@ -6,6 +6,8 @@ import { useRef, useState, type KeyboardEvent } from "react";
 import { toArabicIndex } from "@/shared/lib/arabic";
 import { cn } from "@/shared/lib/utils";
 import { buttonVariants } from "@/shared/ui/button";
+import { IsolatedHandles } from "@/shared/ui/IsolatedHandles";
+import { ShareButton } from "@/features/share/components/ShareButton";
 import { platforms } from "../data/platforms";
 import { PlatformPreview } from "./PlatformPreview";
 
@@ -35,7 +37,7 @@ export const PlatformTabs = () => {
   };
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="w-full">
       <div
         role="tablist"
         aria-label="منصّاتنا"
@@ -99,7 +101,13 @@ export const PlatformTabs = () => {
                     </span>
                   )}
                 </div>
-                <span dir="ltr" className="self-start font-mono text-xs text-neutral/70">
+                <span
+                  dir="ltr"
+                  className={cn(
+                    "self-start text-xs text-neutral/70",
+                    /[؀-ۿ]/.test(platform.handle) ? "font-sans" : "font-mono",
+                  )}
+                >
                   <bdi>{platform.handle}</bdi>
                 </span>
               </div>
@@ -112,7 +120,9 @@ export const PlatformTabs = () => {
                       <span className="font-sans text-sm font-bold text-violet/60">
                         <bdi>{toArabicIndex(index + 1)}</bdi>
                       </span>
-                      <span className="text-[15px] leading-[1.8] text-neutral">{step}</span>
+                      <span className="text-[15px] leading-[1.8] text-neutral">
+                        <IsolatedHandles text={step} />
+                      </span>
                     </li>
                   ))}
                 </ol>
@@ -130,7 +140,12 @@ export const PlatformTabs = () => {
                 </ul>
               </div>
 
-              {isLive ? (
+              {platform.key === "web" ? (
+                <ShareButton variant="default" size="lg" className="self-start">
+                  {platform.cta}
+                  <ArrowUpLeft className="size-4" />
+                </ShareButton>
+              ) : isLive ? (
                 <a
                   href={platform.href}
                   target="_blank"
@@ -141,7 +156,7 @@ export const PlatformTabs = () => {
                     className: "self-start",
                   })}
                 >
-                  افتح {platform.name}
+                  {platform.cta}
                   <ArrowUpLeft className="size-4" />
                 </a>
               ) : (
@@ -157,7 +172,7 @@ export const PlatformTabs = () => {
               )}
             </div>
 
-            <div className="flex items-center justify-center rounded-2xl bg-muted/40 p-6 md:p-8">
+            <div className="order-first flex items-center justify-center rounded-2xl bg-muted/40 p-6 md:order-none md:p-8">
               <div className="w-full max-w-sm">
                 <PlatformPreview platform={platform} />
               </div>

--- a/apps/web/src/features/landing/components/PlatformsSection.tsx
+++ b/apps/web/src/features/landing/components/PlatformsSection.tsx
@@ -3,8 +3,8 @@ import { Reveal } from "./Reveal";
 import { SectionHeading } from "./SectionHeading";
 
 export const PlatformsSection = () => (
-  <section id="platforms" className="bg-muted/40 px-6 py-28 md:py-36">
-    <div className="mx-auto max-w-6xl">
+  <section id="platforms" className="bg-muted/40 py-20 md:py-28">
+    <div className="mx-auto max-w-7xl px-6 md:px-10">
       <SectionHeading
         label="أينما كنت"
         title="منصّاتنا"

--- a/apps/web/src/features/landing/components/RewardSection.tsx
+++ b/apps/web/src/features/landing/components/RewardSection.tsx
@@ -4,7 +4,7 @@ import { Reveal } from "./Reveal";
 import { SectionHeading } from "./SectionHeading";
 
 export const RewardSection = () => (
-  <section id="reward" className="night-bg px-6 py-28 text-paper md:py-36">
+  <section id="reward" className="night-bg px-6 py-20 text-paper md:py-28">
     <div className="mx-auto max-w-6xl">
       <SectionHeading label="الأجر" title="أجرٌ يجري إليك" tone="dark" />
 

--- a/apps/web/src/features/landing/components/SectionHeading.tsx
+++ b/apps/web/src/features/landing/components/SectionHeading.tsx
@@ -15,7 +15,7 @@ export const SectionHeading = ({
   tone = "light",
 }: SectionHeadingProps) => (
   <Reveal>
-    <div className="mb-16 flex flex-col items-center gap-3 text-center">
+    <div className="mb-12 flex flex-col items-center gap-3 text-center md:mb-16">
       <span
         className={cn(
           "text-sm tracking-[0.18em]",

--- a/apps/web/src/features/landing/components/ShareSection.tsx
+++ b/apps/web/src/features/landing/components/ShareSection.tsx
@@ -1,45 +1,24 @@
-import { buttonVariants } from "@/shared/ui/button";
+import { ShareButton } from "@/features/share/components/ShareButton";
 import { Reveal } from "./Reveal";
-import { DiscordIcon, XIcon } from "./icons";
-
-const tweetText = encodeURIComponent("ادْعُونِي · تذكير يومي بالدعاء");
-const tweetIntent = `https://twitter.com/intent/tweet?text=${tweetText}&url=https://www.ad3oni.com`;
-const discordInvite =
-  "https://discord.com/api/oauth2/authorize?client_id=1159198588782518292&permissions=26624&scope=bot%20applications.commands";
 
 export const ShareSection = () => (
-  <section id="share" className="night-bg px-6 py-28 text-paper md:py-36">
-    <Reveal>
-      <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-        <span className="text-sm tracking-[0.18em] text-lilac">كن جزءًا منها</span>
-        <h2 className="font-display text-4xl text-paper md:text-5xl">
-          ذكّرنا بدعوة، وذكّر بها غيرك
-        </h2>
-        <p className="max-w-xl text-lg leading-[2] text-paper/70">
-          شارك دعاء اليوم مع من تحب، أو ادعُ بوت ادْعُونِي إلى خادمك ليذكّر أعضاءك بالخير كل يوم.
-        </p>
+  <section id="share" className="bg-paper py-20 md:py-28">
+    <div className="mx-auto max-w-7xl px-6 md:px-10">
+      <Reveal>
+        <div className="night-bg flex w-full flex-col items-center gap-8 rounded-[2.5rem] px-6 py-20 text-center text-paper md:px-10 md:py-24">
+          <span className="text-sm tracking-[0.18em] text-lilac">كن جزءًا منها</span>
+          <h2 className="font-display text-4xl text-paper md:text-5xl">
+            ذكّرنا بدعوة، وذكّر بها غيرك
+          </h2>
+          <p className="max-w-xl text-lg leading-[2] text-paper/70">
+            شارك دعاء اليوم مع من تحب، أو ادعُ بوت ادْعُونِي إلى سيرفرك ليذكّر أعضاءك بالخير كل يوم.
+          </p>
 
-        <div className="flex flex-col items-center gap-3 sm:flex-row">
-          <a
-            href={tweetIntent}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonVariants({ variant: "paper", size: "lg" })}
-          >
-            <XIcon className="size-4" />
-            شاركه على إكس
-          </a>
-          <a
-            href={discordInvite}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonVariants({ variant: "outline", size: "lg", className: "text-paper" })}
-          >
-            <DiscordIcon className="size-5" />
-            ادعُ البوت لخادمك
-          </a>
+          <ShareButton variant="paper" size="lg">
+            شارك دعاءك
+          </ShareButton>
         </div>
-      </div>
-    </Reveal>
+      </Reveal>
+    </div>
   </section>
 );

--- a/apps/web/src/features/landing/components/SiteNav.tsx
+++ b/apps/web/src/features/landing/components/SiteNav.tsx
@@ -5,8 +5,8 @@ import { AnimatePresence } from "motion/react";
 import { useDisclosure } from "@/shared/hooks/useDisclosure";
 import { useHideOnScroll } from "@/shared/hooks/useHideOnScroll";
 import { useScrolledPastViewport } from "@/shared/hooks/useScrolledPastViewport";
-import { buttonVariants } from "@/shared/ui/button";
 import { cn } from "@/shared/lib/utils";
+import { ShareButton } from "@/features/share/components/ShareButton";
 import { navLinks } from "../data/navigation";
 import { MenuToggle } from "./MenuToggle";
 import { MobileMenu } from "./MobileMenu";
@@ -50,9 +50,9 @@ export const SiteNav = () => {
                 {link.label}
               </a>
             ))}
-            <a href="#share" className={buttonVariants({ variant: "paper", size: "sm" })}>
+            <ShareButton variant="paper" size="sm">
               شاركنا دعاءك
-            </a>
+            </ShareButton>
           </div>
 
           <div className="relative z-50 md:hidden">

--- a/apps/web/src/features/landing/data/navigation.ts
+++ b/apps/web/src/features/landing/data/navigation.ts
@@ -4,8 +4,8 @@ export type NavLink = {
 };
 
 export const navLinks: NavLink[] = [
-  { label: "كيف تعمل", href: "#how" },
   { label: "عن ادْعُونِي", href: "#about" },
+  { label: "كيف تعمل", href: "#how" },
   { label: "منصّاتنا", href: "#platforms" },
   { label: "شاركنا", href: "#share" },
 ];

--- a/apps/web/src/features/landing/data/platforms.ts
+++ b/apps/web/src/features/landing/data/platforms.ts
@@ -8,6 +8,7 @@ export type Platform = {
   handle: string;
   description: string;
   href: string;
+  cta: string;
   status: "live" | "soon";
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   steps: string[];
@@ -21,6 +22,7 @@ export const platforms: Platform[] = [
     handle: "ad3oni.com",
     description: "افتح الموقع في أي وقت لتقرأ دعاء اليوم وتشارك دعاءك.",
     href: "https://www.ad3oni.com",
+    cta: "شاركنا دعاءك",
     status: "live",
     icon: Globe,
     steps: [
@@ -41,6 +43,7 @@ export const platforms: Platform[] = [
     handle: "@ad3oni_",
     description: "دعاء يومي يصلك في موجزك، تشاركه بضغطة واحدة.",
     href: "https://twitter.com/ad3oni_",
+    cta: "تابِعنا على إكس",
     status: "live",
     icon: XIcon,
     steps: [
@@ -59,12 +62,13 @@ export const platforms: Platform[] = [
     key: "discord",
     name: "ديسكورد",
     handle: "بوت ادْعُونِي",
-    description: "ادعُ البوت إلى خادمك ليذكّر أعضاءك بدعاء اليوم تلقائيًا.",
+    description: "ادعُ البوت إلى سيرفرك ليذكّر أعضاءك بدعاء اليوم تلقائيًا.",
     href: "https://discord.com/api/oauth2/authorize?client_id=1159198588782518292&permissions=26624&scope=bot%20applications.commands",
+    cta: "أضِف البوت لسيرفرك",
     status: "live",
     icon: DiscordIcon,
     steps: [
-      "ادعُ البوت إلى خادمك",
+      "ادعُ البوت إلى سيرفرك",
       "اختر القناة ووقت التذكير",
       "يذكّر الأعضاء تلقائيًا كل يوم",
     ],
@@ -81,6 +85,7 @@ export const platforms: Platform[] = [
     handle: "App Store",
     description: "تطبيق ادْعُونِي لنظام iOS، تذكير بالدعاء بين يديك.",
     href: "#",
+    cta: "حمّله من App Store",
     status: "soon",
     icon: AppleIcon,
     steps: [
@@ -101,6 +106,7 @@ export const platforms: Platform[] = [
     handle: "Google Play",
     description: "تطبيق ادْعُونِي لنظام Android، قريبًا على جهازك.",
     href: "#",
+    cta: "حمّله من Google Play",
     status: "soon",
     icon: AndroidIcon,
     steps: [

--- a/apps/web/src/features/share/components/ShareButton.tsx
+++ b/apps/web/src/features/share/components/ShareButton.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { VariantProps } from "class-variance-authority";
+import { buttonVariants } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/utils";
+import { useShareModal } from "../store";
+
+type ShareButtonProps = VariantProps<typeof buttonVariants> & {
+  children: ReactNode;
+  className?: string;
+  onClick?: () => void;
+};
+
+export const ShareButton = ({
+  variant,
+  size,
+  className,
+  children,
+  onClick,
+}: ShareButtonProps) => {
+  const open = useShareModal((state) => state.open);
+
+  const handleClick = () => {
+    onClick?.();
+    open();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(buttonVariants({ variant, size }), className)}
+    >
+      {children}
+    </button>
+  );
+};

--- a/apps/web/src/features/share/components/ShareModal.tsx
+++ b/apps/web/src/features/share/components/ShareModal.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { X } from "lucide-react";
+import { useLockBodyScroll } from "@/shared/hooks/useLockBodyScroll";
+import { useMediaQuery } from "@/shared/hooks/useMediaQuery";
+import { useShareModal } from "../store";
+import { SharePrayerForm } from "./SharePrayerForm";
+
+type SharePanelProps = {
+  onClose: () => void;
+  isDesktop: boolean;
+  reduce: boolean;
+};
+
+const SharePanel = ({ onClose, isDesktop, reduce }: SharePanelProps) => {
+  useLockBodyScroll(true);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKey);
+
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [onClose]);
+
+  const panelMotion = reduce
+    ? { initial: { opacity: 0 }, animate: { opacity: 1 }, exit: { opacity: 0 } }
+    : isDesktop
+      ? {
+          initial: { opacity: 0, scale: 0.96, y: 8 },
+          animate: { opacity: 1, scale: 1, y: 0 },
+          exit: { opacity: 0, scale: 0.96, y: 8 },
+        }
+      : { initial: { y: "100%" }, animate: { y: 0 }, exit: { y: "100%" } };
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-[100] flex items-end justify-center md:items-center md:p-6"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <button
+        type="button"
+        aria-hidden
+        tabIndex={-1}
+        onClick={onClose}
+        className="absolute inset-0 bg-night/50 backdrop-blur-sm"
+      />
+
+      <motion.div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-modal-title"
+        {...panelMotion}
+        transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+        className="relative flex max-h-[90vh] w-full flex-col overflow-y-auto rounded-t-3xl bg-paper p-6 pb-8 md:max-w-md md:rounded-3xl md:p-8"
+      >
+        <div className="mx-auto mb-5 h-1.5 w-12 shrink-0 rounded-full bg-neutral/20 md:hidden" />
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-4">
+            <h2 id="share-modal-title" className="font-display text-2xl text-royal">
+              شارك دعاءك
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="إغلاق"
+              className="-me-1 flex size-9 shrink-0 items-center justify-center rounded-full text-neutral transition-colors hover:bg-muted hover:text-royal"
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+          <p className="text-sm leading-[1.8] text-neutral">
+            اكتب دعاءً صادقًا، وسنشاركه ليصل غيرك فتُكتب لك أجوره بإذن الله.
+          </p>
+        </div>
+
+        <div className="mt-6">
+          <SharePrayerForm />
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+};
+
+export const ShareModal = () => {
+  const isOpen = useShareModal((state) => state.isOpen);
+  const close = useShareModal((state) => state.close);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const reduce = useReducedMotion();
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <SharePanel onClose={close} isDesktop={isDesktop} reduce={Boolean(reduce)} />
+      )}
+    </AnimatePresence>
+  );
+};

--- a/apps/web/src/features/share/components/SharePrayerForm.tsx
+++ b/apps/web/src/features/share/components/SharePrayerForm.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useWatch } from "react-hook-form";
+import { cn } from "@/shared/lib/utils";
+import { toArabicIndex } from "@/shared/lib/arabic";
+import { Button } from "@/shared/ui/button";
+import { MAX_LENGTH, sharePrayerSchema, type SharePrayerValues } from "../schema";
+
+export const SharePrayerForm = () => {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors, isValid },
+  } = useForm<SharePrayerValues>({
+    resolver: zodResolver(sharePrayerSchema),
+    mode: "onChange",
+    defaultValues: { text: "" },
+  });
+
+  const value = useWatch({ control, name: "text" }) ?? "";
+  const used = value.length;
+  const ratio = Math.min(used / MAX_LENGTH, 1);
+  const warning = ratio >= 0.8 && ratio < 1;
+  const full = ratio >= 1;
+
+  const onSubmit = handleSubmit(() => undefined);
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <label htmlFor="prayer-text" className="text-sm font-medium text-royal">
+            دعاؤك
+          </label>
+          <span
+            dir="ltr"
+            className={cn(
+              "text-xs tabular-nums",
+              full ? "text-red-600" : warning ? "text-amber-600" : "text-neutral/60",
+            )}
+          >
+            <bdi>
+              {toArabicIndex(used)} / {toArabicIndex(MAX_LENGTH)}
+            </bdi>
+          </span>
+        </div>
+
+        <textarea
+          id="prayer-text"
+          rows={5}
+          maxLength={MAX_LENGTH}
+          autoFocus
+          placeholder="اللهم اشرح صدري، ويسّر أمري…"
+          aria-invalid={Boolean(errors.text)}
+          {...register("text")}
+          className={cn(
+            "w-full resize-none rounded-2xl border bg-paper p-4 text-[15px] leading-[1.9] text-royal outline-none transition-colors placeholder:text-neutral/45",
+            errors.text
+              ? "border-red-400 focus:border-red-500 focus:ring-[3px] focus:ring-red-500/15"
+              : "border-border focus:border-violet focus:ring-[3px] focus:ring-violet/15",
+          )}
+        />
+
+        <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={cn(
+              "h-full rounded-full transition-all duration-300",
+              full ? "bg-red-500" : warning ? "bg-amber-500" : "bg-violet",
+            )}
+            style={{ width: `${ratio * 100}%` }}
+          />
+        </div>
+
+        {errors.text ? (
+          <p className="text-xs text-red-600">{errors.text.message}</p>
+        ) : (
+          <p className="text-xs text-neutral/55">يظهر دعاؤك للجميع بعد المراجعة.</p>
+        )}
+      </div>
+
+      <Button type="submit" size="lg" disabled={!isValid}>
+        أرسل دعاءك
+      </Button>
+    </form>
+  );
+};

--- a/apps/web/src/features/share/schema.ts
+++ b/apps/web/src/features/share/schema.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const MIN_LENGTH = 3;
+export const MAX_LENGTH = 280;
+
+const allowedPattern =
+  /^[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-﻿\s،؛؟!.…«»()ـ]+$/u;
+const arabicLetter = /[ء-يٱ-ۓۺ-ۼ]/u;
+
+export const sharePrayerSchema = z.object({
+  text: z
+    .string()
+    .superRefine((raw, ctx) => {
+      const value = raw.trim();
+
+      if (value.length > 0 && !allowedPattern.test(value)) {
+        ctx.addIssue({ code: "custom", message: "اكتب بالعربية فقط" });
+        return;
+      }
+      if (value.length > 0 && !arabicLetter.test(value)) {
+        ctx.addIssue({ code: "custom", message: "اكتب دعاءً بالعربية" });
+        return;
+      }
+      if (value.length < MIN_LENGTH) {
+        ctx.addIssue({ code: "custom", message: "الدعاء قصير جدًا" });
+        return;
+      }
+      if (value.length > MAX_LENGTH) {
+        ctx.addIssue({ code: "custom", message: "تجاوزت الحد المسموح به" });
+      }
+    })
+    .transform((raw) => raw.trim()),
+});
+
+export type SharePrayerValues = z.infer<typeof sharePrayerSchema>;

--- a/apps/web/src/features/share/store.ts
+++ b/apps/web/src/features/share/store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type ShareModalState = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+};
+
+export const useShareModal = create<ShareModalState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/apps/web/src/shared/hooks/useLockBodyScroll.ts
+++ b/apps/web/src/shared/hooks/useLockBodyScroll.ts
@@ -2,16 +2,25 @@
 
 import { useEffect } from "react";
 
+let lockCount = 0;
+let originalOverflow = "";
+
 export const useLockBodyScroll = (locked: boolean) => {
   useEffect(() => {
     if (!locked) return;
 
     const root = document.documentElement;
-    const original = root.style.overflow;
-    root.style.overflow = "hidden";
+    if (lockCount === 0) {
+      originalOverflow = root.style.overflow;
+      root.style.overflow = "hidden";
+    }
+    lockCount += 1;
 
     return () => {
-      root.style.overflow = original;
+      lockCount -= 1;
+      if (lockCount === 0) {
+        root.style.overflow = originalOverflow;
+      }
     };
   }, [locked]);
 };

--- a/apps/web/src/shared/hooks/useMediaQuery.ts
+++ b/apps/web/src/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export const useMediaQuery = (query: string) => {
+  const subscribe = (onChange: () => void) => {
+    const list = window.matchMedia(query);
+    list.addEventListener("change", onChange);
+    return () => list.removeEventListener("change", onChange);
+  };
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+};

--- a/apps/web/src/shared/ui/IsolatedHandles.tsx
+++ b/apps/web/src/shared/ui/IsolatedHandles.tsx
@@ -1,0 +1,13 @@
+import { Fragment, type ReactNode } from "react";
+
+const handlePattern = /(@\w+)/g;
+const isHandle = (part: string) => part.startsWith("@");
+
+export const IsolatedHandles = ({ text }: { text: string }): ReactNode =>
+  text.split(handlePattern).map((part, index) =>
+    isHandle(part) ? (
+      <bdi key={index}>{part}</bdi>
+    ) : (
+      <Fragment key={index}>{part}</Fragment>
+    ),
+  );

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,10 @@
         "turbo": "^2.9.16",
       },
     },
+    "apps/api": {
+      "name": "api",
+      "version": "0.1.1",
+    },
     "apps/brand": {
       "name": "@ad3oni/brand",
       "dependencies": {
@@ -55,8 +59,11 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
+        "@tanstack/react-query": "^5.101.0",
+        "axios": "^1.17.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.17.0",
@@ -64,7 +71,10 @@
         "next": "16.2.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-hook-form": "^7.77.0",
         "tailwind-merge": "^3.6.0",
+        "zod": "^4.4.3",
+        "zustand": "^5.0.14",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -190,6 +200,8 @@
     "@fontsource/rakkas": ["@fontsource/rakkas@5.2.8", "", {}, "sha512-pRHD45oXlCKpXN/a0duCGJOMxjokAUeGXP0l9k2WIxQ45bSdtaXNBAHQNd9lesPJ8glaVhEJu0rf1O/pOq8Vdg=="],
 
     "@fontsource/tajawal": ["@fontsource/tajawal@5.2.7", "", {}, "sha512-EzswJ4JoFmYQ7hn7O5Do7Azd1tjzujSEzN+DvTZNcAwZ3usfPvEJ3hTQtYv9VN+mUH4flOi6LedtqCkVUHZs9A=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@5.4.0", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -511,6 +523,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@stylistic/eslint-plugin": ["@stylistic/eslint-plugin@5.10.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/types": "^8.56.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "estraverse": "^5.3.0", "picomatch": "^4.0.3" }, "peerDependencies": { "eslint": "^9.0.0 || ^10.0.0" } }, "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -569,25 +583,25 @@
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.5", "", { "dependencies": { "@tanstack/devtools": "0.12.2" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-orVsRJ7oAXFb7oyafQCgx9YuK44jpILh5T/ddYuxAsolNfN5DZBr5/NLrWErD7HCGIzvYzg1TZI4sPxmiKvtvA=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.100.14", "", { "dependencies": { "@tanstack/query-core": "5.100.14" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.101.0", "", { "dependencies": { "@tanstack/query-core": "5.101.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.170.9", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.7", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-rXXztp6GyXFwResQR0jdvkf52wy/sAQqze3OR08+8uNM7nHir1P46qBrwg2TL5EEtX+0WUho4BZ/nMpAgQVB6A=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.11", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.9", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-gP2vzdyaI8Ow/Uz/MRPfK2wN09YwRI0Y/oF74Wuy9R3KmjbfJv2tLrkM+Onu1xWklSn3ugZarMPJXRE0kzrJTA=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.167.0", "", { "dependencies": { "@tanstack/router-devtools-core": "1.168.0" }, "peerDependencies": { "@tanstack/react-router": "^1.170.0", "@tanstack/router-core": "^1.170.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w=="],
 
     "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.167.1", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.169.1" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.168.16", "", { "dependencies": { "@tanstack/react-router": "1.170.9", "@tanstack/react-start-client": "1.168.6", "@tanstack/react-start-rsc": "0.1.15", "@tanstack/react-start-server": "1.167.11", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.5", "@tanstack/start-plugin-core": "1.171.8", "@tanstack/start-server-core": "1.169.6", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "@vitejs/plugin-rsc": "*", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "@vitejs/plugin-rsc", "vite"] }, "sha512-ZkrGThxJG0SPg5V+VB4C+7KKx8kl1vo1lQY9FR2t6EqNKfZhl5N9qpkPOeyJNhse1pqe8Ihbv8LNL9c1/SohkQ=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.168.20", "", { "dependencies": { "@tanstack/react-router": "1.170.11", "@tanstack/react-start-client": "1.168.8", "@tanstack/react-start-rsc": "0.1.19", "@tanstack/react-start-server": "1.167.14", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.7", "@tanstack/start-plugin-core": "1.171.12", "@tanstack/start-server-core": "1.169.9", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "@vitejs/plugin-rsc": "*", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "@vitejs/plugin-rsc", "vite"] }, "sha512-Z3PGRmElaFsnECzVldUoWIcYPb3FjZ1D6v01aE1jYsovs6/cjbxBL7MHagSyjuYghyt29oNKJpbsHiFDSmTSnA=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.168.6", "", { "dependencies": { "@tanstack/react-router": "1.170.9", "@tanstack/router-core": "1.171.7", "@tanstack/start-client-core": "1.170.5" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-6G/ef89hx3yWfoHLKpDxDpgMsje889bh8tpy6SMeELrCW6ob8x0G+peoFpB5zhNVE03wCFXhImM6KkZFRwSyaQ=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.168.8", "", { "dependencies": { "@tanstack/react-router": "1.170.11", "@tanstack/router-core": "1.171.9", "@tanstack/start-client-core": "1.170.7" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-CW2P0riDN+IQCuXx33R1H0ONEW3NespMfb2t6qSesOyuoPjnh4earDKaZsWYEVvewzx8465BOhOmh+nxEJRjJg=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.15", "", { "dependencies": { "@tanstack/react-router": "1.170.9", "@tanstack/react-start-server": "1.167.11", "@tanstack/router-core": "1.171.7", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.5", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.8", "@tanstack/start-server-core": "1.169.6", "@tanstack/start-storage-context": "1.167.9", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-AdO+3OQicxFibsXEOIG2u2aRIAc1KIWMC98iiwaIUw/1ObP7uilZcYQynwdDeqsGKd0Ulr+tXZXebLdQwV4OeA=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.19", "", { "dependencies": { "@tanstack/react-router": "1.170.11", "@tanstack/react-start-server": "1.167.14", "@tanstack/router-core": "1.171.9", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.7", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.12", "@tanstack/start-server-core": "1.169.9", "@tanstack/start-storage-context": "1.167.11", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-UKUNj93NrV1gp/eAV/wvvj745sHFS6UPEL5rV2hbpU0W7IYWjzk6fOgNOKxUzFMkblT6NSAJweR7bPDV5GA5ww=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.11", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-router": "1.170.9", "@tanstack/router-core": "1.171.7", "@tanstack/start-client-core": "1.170.5", "@tanstack/start-server-core": "1.169.6" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-7IOSbMJ7mvNbcI6/LAHsYbhR+oIxDfZlWSBau1E/l2tY2HSnKdtu+tj1yTY7zgwqEdn14IyGFSxpHe/eTFNB5g=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.14", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-router": "1.170.11", "@tanstack/router-core": "1.171.9", "@tanstack/start-client-core": "1.170.7", "@tanstack/start-server-core": "1.169.9" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-Cma1M0ofxPxpmax1aQp6NM38N62MCgfEmto6RqfptZHd5UOlMp1dFf5zsnEukJq6vDVxg4lQyUgE2+qJuo2PmA=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.171.7", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.171.9", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-QM5ZwLT9c5ZcTJW0QQZRRIBC4qjImUyUCXCVyuYVOF9xr76XLsJSX4F2dOxr9VptAv+W+TkWNOYdX8VaO9kdgA=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.0", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.170.0", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg=="],
 
@@ -599,15 +613,15 @@
 
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.1", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-62layyTGmclHDQS/eidwKRfN1hhCKwViG7iEBcVmL0MXgcAB3OOucWCEcDDGd9Cu11H6b4QQ5oOo47MWIqwz0A=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.170.5", "", { "dependencies": { "@tanstack/router-core": "1.171.7", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.9", "seroval": "^1.5.4" } }, "sha512-rtL6JyEB7/zeylgOjwtFEtmTIwRUm4Mf4bEhp2yUVk8kB4zLlmYcpSAFbb/aIrLp/Yl9XS2dx3OxB7oIPUuplg=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.170.7", "", { "dependencies": { "@tanstack/router-core": "1.171.9", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.11", "seroval": "^1.5.4" } }, "sha512-LKNHeK3n8DZ2ub1KpidWCISvJNq7wGuErrd2oSyoUDHSo90ldl7JJcG4OpbDS7GQjqIZ79M47eklajwgKXBxrQ=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.162.0", "", {}, "sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.8", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.1", "@tanstack/router-core": "1.171.7", "@tanstack/router-generator": "1.167.11", "@tanstack/router-plugin": "1.168.12", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.5", "@tanstack/start-server-core": "1.169.6", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-Eoe83LD3N7AQgsjb+uRq+DjUE82+e8liYqzfIVoZ03t4+XfHtTbMBB+f6XK2kUzTv4QBG7ZmZU959jWwQHfVTQ=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.12", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.1", "@tanstack/router-core": "1.171.9", "@tanstack/router-generator": "1.167.13", "@tanstack/router-plugin": "1.168.14", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.7", "@tanstack/start-server-core": "1.169.9", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-VRqqcVDFm17dEmR8zOt3K/+FpHRMd36jakgdqfRQy9s9VPPfv+CRwk80iHe5AnOnm0UrHCQ0RLVAmZPBwOQ8Dw=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.6", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.7", "@tanstack/start-client-core": "1.170.5", "@tanstack/start-storage-context": "1.167.9", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-Qf+Uinnc5Ak79QGD6pJsiK0IfUlWkyJNy+h9vTwOtVLBvmq/fR7GjBuf5ymidI/7jK/YQWVuw2aaEE6MHBC+iw=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.9", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.9", "@tanstack/start-client-core": "1.170.7", "@tanstack/start-storage-context": "1.167.11", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-i2OXl+svinZI+7tE2FTQSc9vLIMp0/3nQAI47zg7cZ/0btmC2g2wVrEUa7pF4bmS2TrKEfmOancbURWfB2YrkA=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.9", "", { "dependencies": { "@tanstack/router-core": "1.171.7" } }, "sha512-RKxJA95HgZXu2lgTCzGi7pShtgz7vyvDTEPOJfJBBMHM2S7SX/WLYTHqfHcYvbOzREXOxEbDQ8Hvtt0Klq8VKg=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.11", "", { "dependencies": { "@tanstack/router-core": "1.171.9" } }, "sha512-19wywJH3jiamctg4BxXme0G9iH+P5qHSILxBbyksTK727shDEZPb6V/NzO2dz4cKFAoB6TdBcKBj/guADClOfQ=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -743,6 +757,8 @@
 
     "ansis": ["ansis@4.3.0", "", {}, "sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg=="],
 
+    "api": ["api@workspace:apps/api"],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
@@ -771,9 +787,13 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
+
+    "axios": ["axios@1.17.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -816,6 +836,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comment-parser": ["comment-parser@1.4.7", "", {}, "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ=="],
 
@@ -862,6 +884,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -981,7 +1005,11 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
 
@@ -1199,6 +1227,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -1293,6 +1325,8 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -1302,6 +1336,8 @@
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-hook-form": ["react-hook-form@7.77.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -1543,6 +1579,10 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
+
+    "@ad3oni/brand/nitro": ["nitro-nightly@3.0.260603-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.9", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.3", "srvx": "^0.11.16", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.2.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.60.4", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-uOSGn2KfRONccyMFNexnyLZLUruQ8Myg8m/tP6DCnI2VxNP27C9Sl6gveEGqbSnuKRxN8Ze1YMz/DmMaA62Qgw=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1565,13 +1605,25 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.101.0", "", {}, "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow=="],
+
+    "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.171.7", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core": ["@tanstack/router-core@1.171.7", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ=="],
+
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.167.13", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.9", "@tanstack/router-utils": "1.162.1", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-DldbCjA8S/CXQBuoyQqr76xqZe9k+H1ymV+ugj2IBHFi4yRzx4z4f2nSsPYlLdpXD2Cf/MEjLncaG7ceY5H5ig=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.14", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.9", "@tanstack/router-generator": "1.167.13", "@tanstack/router-utils": "1.162.1", "@tanstack/virtual-file-routes": "1.162.0", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.11", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-z+3vYJ7ouNnMzBIC1hsNWsxaQFu9Gf0WSdE3jBHWa326ipnONqDD5KeCqWGczq0HMdZY4UsDjyfvjucxXhrb0A=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "eslint/@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
@@ -1620,6 +1672,8 @@
     "web/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "eslint-plugin-import-x/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 


### PR DESCRIPTION
## Share-prayer modal
- Global Zustand store + `ShareButton` trigger; every share CTA (desktop nav, mobile menu, community section, share section, web platform tab) opens it.
- Responsive shell: small centered modal on desktop, bottom sheet on mobile (`useMediaQuery`-driven animation), backdrop/Escape/scroll-lock close, focus restore, reduced-motion aware.
- Rich prayer field: live `used / max` counter (Arabic numerals), progress line that fills and turns amber → red near the 280-char limit, and validation that checks **Arabic-with-tashkeel characters before length** (via `superRefine`).
- `useLockBodyScroll` made reference-counted so the mobile menu → sheet hand-off doesn't unlock the page.

## Landing polish
- Unified, tighter section rhythm (`py-20 md:py-28`) and consistent heading margins; AboutSection now uses the shared `SectionHeading`.
- Share + platform-tabs cards aligned to the navbar width; nav links reordered to match section scroll order.
- Per-platform CTA labels; Discord/share copy uses سيرفرك; `@handle` isolation via `IsolatedHandles`; Arabic text off `font-mono`; browser-frame URL centered; modal header X aligned with title.
- Mobile: platform preview now stacks above the text.

## Scrollbar
- Thin, transparent, overlay scrollbar with no reserved gutter (matches the Rattil approach; now a global rule).

## Deps
- Added zustand, react-hook-form, @hookform/resolvers, zod, @tanstack/react-query, axios (foundation; backend wiring is next).

Build, lint, and typecheck all pass.