### PR TITLE
feat(web): connect frontend to the API (hero, our-prayers, share)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/prayers/mappers.py
+++ b/apps/api/src/features/prayers/mappers.py
@@ -11,6 +11,7 @@ def to_prayer(record: dict[str, Any]) -> Prayer:
     return Prayer(
         id=record["id"],
         text=record["text"],
+        text_diacritized=record.get("text_diacritized"),
         status=record["status"],
         category=to_category(category_record) if category_record else None,
         type=to_prayer_type(type_record) if type_record else None,

--- a/apps/api/src/features/prayers/schema.py
+++ b/apps/api/src/features/prayers/schema.py
@@ -18,6 +18,7 @@ TaxonomySlug = Annotated[
 class Prayer(CamelModel):
     id: str
     text: str
+    text_diacritized: str | None = None
     status: str
     category: Category | None = None
     type: PrayerType | None = None

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -18,6 +18,7 @@ PRAYER_TYPE: dict[str, Any] = {"id": "t1", "name": "نبوي", "slug": "propheti
 PRAYER: dict[str, Any] = {
     "id": "p1",
     "text": "اللهم اغفر لي وارحمني",
+    "text_diacritized": "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي",
     "status": "confirmed",
     "created": "2026-05-30 00:00:00.000Z",
     "updated": "2026-05-30 00:00:00.000Z",

--- a/apps/api/tests/test_prayers.py
+++ b/apps/api/tests/test_prayers.py
@@ -9,6 +9,7 @@ def test_list_prayers_returns_paginated_envelope(client: TestClient) -> None:
     assert body["perPage"] == 20
     prayer = body["items"][0]
     assert prayer["status"] == "confirmed"
+    assert prayer["textDiacritized"] == "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي"
     assert prayer["category"]["group"]["slug"] == "emotion"
     assert prayer["type"]["slug"] == "prophetic"
 

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.3"
+version = "0.1.4"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,6 +6,8 @@ RUN bun install --frozen-lockfile
 FROM oven/bun:1.3.14-slim AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN bun run build

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Rakkas, Geist_Mono } from "next/font/google";
 import localFont from "next/font/local";
+import { Providers } from "./providers";
 import "./globals.css";
 
 const rakkas = Rakkas({
@@ -49,7 +50,9 @@ export default function RootLayout({
       dir="rtl"
       className={`${rakkas.variable} ${tajawal.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full">{children}</body>
+      <body className="min-h-full">
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,26 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { getQueryClient } from "@/shared/api/query-client";
+import {
+  prayersQueryOptions,
+  randomPrayerQueryOptions,
+} from "@/features/prayers/queries";
 import { LandingPage } from "@/features/landing/LandingPage";
 
-export default function Home() {
-  return <LandingPage />;
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const queryClient = getQueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery(randomPrayerQueryOptions()),
+    queryClient.prefetchQuery(
+      prayersQueryOptions({ perPage: 14, sort: "-created" }),
+    ),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <LandingPage />
+    </HydrationBoundary>
+  );
 }

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { getQueryClient } from "@/shared/api/query-client";
+
+export const Providers = ({ children }: { children: ReactNode }) => {
+  const queryClient = getQueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};

--- a/apps/web/src/features/landing/components/Hero.tsx
+++ b/apps/web/src/features/landing/components/Hero.tsx
@@ -2,7 +2,9 @@
 
 import { ChevronDown } from "lucide-react";
 import { motion, useReducedMotion, type Variants } from "motion/react";
+import { useQuery } from "@tanstack/react-query";
 import { buttonVariants } from "@/shared/ui/button";
+import { randomPrayerQueryOptions } from "@/features/prayers/queries";
 import { dailyPrayer } from "../data/prayer";
 import { BracePrayer } from "./BracePrayer";
 
@@ -20,6 +22,10 @@ const item: Variants = {
 
 export const Hero = () => {
   const reduceMotion = useReducedMotion();
+  const { data: prayer } = useQuery(randomPrayerQueryOptions());
+
+  const prayerText = prayer?.textDiacritized ?? prayer?.text ?? dailyPrayer.text;
+  const prayerLabel = prayer?.category?.name ?? dailyPrayer.attribution;
 
   return (
     <section className="dotted-bg relative flex min-h-svh items-center overflow-hidden text-paper">
@@ -43,13 +49,13 @@ export const Hero = () => {
         <motion.div variants={item}>
           <BracePrayer>
             <p className="font-display text-4xl text-paper sm:text-5xl md:text-6xl">
-              {dailyPrayer.text}
+              {prayerText}
             </p>
           </BracePrayer>
         </motion.div>
 
         <motion.p variants={item} className="text-sm text-paper/55">
-          <bdi>{dailyPrayer.attribution}</bdi>
+          <bdi>{prayerLabel}</bdi>
         </motion.p>
 
         <motion.div

--- a/apps/web/src/features/landing/components/PrayerCard.tsx
+++ b/apps/web/src/features/landing/components/PrayerCard.tsx
@@ -9,9 +9,11 @@ export const PrayerCard = ({ prayer }: PrayerCardProps) => (
     dir="rtl"
     className="flex h-full flex-col gap-3 rounded-2xl border border-border bg-paper p-6"
   >
-    <span className="self-start rounded-full bg-muted px-2.5 py-1 text-[11px] text-violet">
-      {prayer.category}
-    </span>
+    {prayer.category ? (
+      <span className="self-start rounded-full bg-muted px-2.5 py-1 text-[11px] text-violet">
+        {prayer.category}
+      </span>
+    ) : null}
     <p className="font-sans text-sm leading-[1.85] text-royal">{prayer.text}</p>
   </article>
 );

--- a/apps/web/src/features/landing/components/PrayerMarquee.tsx
+++ b/apps/web/src/features/landing/components/PrayerMarquee.tsx
@@ -1,9 +1,17 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
 import { cn } from "@/shared/lib/utils";
+import { prayersQueryOptions } from "@/features/prayers/queries";
+import type { Prayer } from "@/features/prayers/types";
 import { communityPrayers, type CommunityPrayer } from "../data/communityPrayers";
 import { PrayerCard } from "./PrayerCard";
 
-const rowOne = communityPrayers;
-const rowTwo = [...communityPrayers.slice(7), ...communityPrayers.slice(0, 7)];
+const toCard = (prayer: Prayer): CommunityPrayer => ({
+  id: prayer.id,
+  text: prayer.textDiacritized ?? prayer.text,
+  category: prayer.category?.name ?? "",
+});
 
 const MarqueeRow = ({
   prayers,
@@ -32,9 +40,19 @@ const MarqueeRow = ({
   </div>
 );
 
-export const PrayerMarquee = () => (
-  <div dir="ltr" className="flex flex-col gap-5">
-    <MarqueeRow prayers={rowOne} />
-    <MarqueeRow prayers={rowTwo} reverse />
-  </div>
-);
+export const PrayerMarquee = () => {
+  const { data } = useQuery(
+    prayersQueryOptions({ perPage: 14, sort: "-created" }),
+  );
+
+  const items = data?.items.length ? data.items.map(toCard) : communityPrayers;
+  const rowOne = items;
+  const rowTwo = [...items.slice(7), ...items.slice(0, 7)];
+
+  return (
+    <div dir="ltr" className="flex flex-col gap-5">
+      <MarqueeRow prayers={rowOne} />
+      <MarqueeRow prayers={rowTwo} reverse />
+    </div>
+  );
+};

--- a/apps/web/src/features/prayers/api.ts
+++ b/apps/web/src/features/prayers/api.ts
@@ -1,0 +1,13 @@
+import { apiGet } from "@/shared/api/axios";
+import type {
+  Page,
+  Prayer,
+  PrayerListParams,
+  RandomPrayerParams,
+} from "./types";
+
+export const fetchPrayers = (params: PrayerListParams = {}) =>
+  apiGet<Page<Prayer>>("/prayers", params);
+
+export const fetchRandomPrayer = (params: RandomPrayerParams = {}) =>
+  apiGet<Prayer>("/prayers/random", params);

--- a/apps/web/src/features/prayers/queries.ts
+++ b/apps/web/src/features/prayers/queries.ts
@@ -1,0 +1,17 @@
+import { queryOptions } from "@tanstack/react-query";
+import { fetchPrayers, fetchRandomPrayer } from "./api";
+import type { PrayerListParams, RandomPrayerParams } from "./types";
+
+export const prayersQueryOptions = (params: PrayerListParams = {}) =>
+  queryOptions({
+    queryKey: ["prayers", "list", params],
+    queryFn: () => fetchPrayers(params),
+    staleTime: 60_000,
+  });
+
+export const randomPrayerQueryOptions = (params: RandomPrayerParams = {}) =>
+  queryOptions({
+    queryKey: ["prayers", "random", params],
+    queryFn: () => fetchRandomPrayer(params),
+    staleTime: Infinity,
+  });

--- a/apps/web/src/features/prayers/types.ts
+++ b/apps/web/src/features/prayers/types.ts
@@ -1,0 +1,54 @@
+export type Group = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+export type Category = {
+  id: string;
+  name: string;
+  slug: string;
+  group?: Group | null;
+};
+
+export type PrayerType = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+export type Prayer = {
+  id: string;
+  text: string;
+  textDiacritized?: string | null;
+  status: string;
+  category?: Category | null;
+  type?: PrayerType | null;
+  created: string;
+  updated: string;
+};
+
+export type Page<T> = {
+  items: T[];
+  page: number;
+  perPage: number;
+  totalItems: number;
+  totalPages: number;
+};
+
+export type PrayerSort = "-created" | "created" | "-updated" | "updated";
+
+export type PrayerListParams = {
+  category?: string;
+  type?: string;
+  group?: string;
+  q?: string;
+  page?: number;
+  perPage?: number;
+  sort?: PrayerSort;
+};
+
+export type RandomPrayerParams = {
+  category?: string;
+  type?: string;
+};

--- a/apps/web/src/features/share/api.ts
+++ b/apps/web/src/features/share/api.ts
@@ -1,0 +1,16 @@
+import { apiPost } from "@/shared/api/axios";
+
+export type SubmitPrayerInput = {
+  text: string;
+  category?: string;
+  type?: string;
+};
+
+export type SubmitPrayerResponse = {
+  id: string;
+  status: string;
+  created: string;
+};
+
+export const submitPrayer = (input: SubmitPrayerInput) =>
+  apiPost<SubmitPrayerResponse>("/prayers", input);

--- a/apps/web/src/features/share/components/ShareModal.tsx
+++ b/apps/web/src/features/share/components/ShareModal.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { useLockBodyScroll } from "@/shared/hooks/useLockBodyScroll";
 import { useMediaQuery } from "@/shared/hooks/useMediaQuery";
+import { Button } from "@/shared/ui/button";
 import { useShareModal } from "../store";
 import { SharePrayerForm } from "./SharePrayerForm";
 
@@ -16,6 +17,8 @@ type SharePanelProps = {
 
 const SharePanel = ({ onClose, isDesktop, reduce }: SharePanelProps) => {
   useLockBodyScroll(true);
+  const view = useShareModal((state) => state.view);
+  const reset = useShareModal((state) => state.reset);
 
   useEffect(() => {
     const previouslyFocused = document.activeElement as HTMLElement | null;
@@ -40,6 +43,8 @@ const SharePanel = ({ onClose, isDesktop, reduce }: SharePanelProps) => {
           exit: { opacity: 0, scale: 0.96, y: 8 },
         }
       : { initial: { y: "100%" }, animate: { y: 0 }, exit: { y: "100%" } };
+
+  const isSuccess = view === "success";
 
   return (
     <motion.div
@@ -70,7 +75,7 @@ const SharePanel = ({ onClose, isDesktop, reduce }: SharePanelProps) => {
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between gap-4">
             <h2 id="share-modal-title" className="font-display text-2xl text-royal">
-              شارك دعاءك
+              {isSuccess ? "جزاك الله خيرًا" : "شارك دعاءك"}
             </h2>
             <button
               type="button"
@@ -81,14 +86,42 @@ const SharePanel = ({ onClose, isDesktop, reduce }: SharePanelProps) => {
               <X className="size-5" />
             </button>
           </div>
-          <p className="text-sm leading-[1.8] text-neutral">
-            اكتب دعاءً صادقًا، وسنشاركه ليصل غيرك فتُكتب لك أجوره بإذن الله.
-          </p>
+          {!isSuccess && (
+            <p className="text-sm leading-[1.8] text-neutral">
+              اكتب دعاءً صادقًا، وسنشاركه ليصل غيرك فتُكتب لك أجوره بإذن الله.
+            </p>
+          )}
         </div>
 
-        <div className="mt-6">
-          <SharePrayerForm />
-        </div>
+        {isSuccess ? (
+          <div className="mt-6 flex flex-col gap-7">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <span className="flex size-14 items-center justify-center rounded-full bg-violet/10 text-violet">
+                <Check className="size-7" />
+              </span>
+              <p className="text-sm leading-[1.9] text-neutral">
+                وصلنا دعاؤك. سيظهر للجميع بعد المراجعة بإذن الله، فتُكتب لك أجوره كلما
+                دعا به أحد.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3">
+              <Button type="button" size="lg" onClick={reset}>
+                شارك دعاءً آخر
+              </Button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-sm text-neutral transition-colors hover:text-royal"
+              >
+                إغلاق
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-6">
+            <SharePrayerForm />
+          </div>
+        )}
       </motion.div>
     </motion.div>
   );

--- a/apps/web/src/features/share/components/SharePrayerForm.tsx
+++ b/apps/web/src/features/share/components/SharePrayerForm.tsx
@@ -4,8 +4,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, useWatch } from "react-hook-form";
 import { cn } from "@/shared/lib/utils";
 import { toArabicIndex } from "@/shared/lib/arabic";
+import { toApiError } from "@/shared/api/errors";
 import { Button } from "@/shared/ui/button";
 import { MAX_LENGTH, sharePrayerSchema, type SharePrayerValues } from "../schema";
+import { useShareModal } from "../store";
+import { useSubmitPrayer } from "../useSubmitPrayer";
 
 export const SharePrayerForm = () => {
   const {
@@ -25,7 +28,23 @@ export const SharePrayerForm = () => {
   const warning = ratio >= 0.8 && ratio < 1;
   const full = ratio >= 1;
 
-  const onSubmit = handleSubmit(() => undefined);
+  const mutation = useSubmitPrayer();
+  const showSuccess = useShareModal((state) => state.showSuccess);
+
+  const onSubmit = handleSubmit((values) =>
+    mutation.mutate(
+      { text: values.text },
+      { onSuccess: () => showSuccess() },
+    ),
+  );
+
+  const submitError = mutation.isError ? toApiError(mutation.error) : null;
+  const submitMessage =
+    submitError?.code === "rate_limited"
+      ? "لقد أرسلت عدة أدعية. انتظر قليلًا ثم حاول مرة أخرى."
+      : submitError
+        ? "تعذّر إرسال دعائك. حاول مرة أخرى."
+        : null;
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-5">
@@ -75,13 +94,15 @@ export const SharePrayerForm = () => {
 
         {errors.text ? (
           <p className="text-xs text-red-600">{errors.text.message}</p>
+        ) : submitMessage ? (
+          <p className="text-xs text-red-600">{submitMessage}</p>
         ) : (
           <p className="text-xs text-neutral/55">يظهر دعاؤك للجميع بعد المراجعة.</p>
         )}
       </div>
 
-      <Button type="submit" size="lg" disabled={!isValid}>
-        أرسل دعاءك
+      <Button type="submit" size="lg" disabled={!isValid || mutation.isPending}>
+        {mutation.isPending ? "جارٍ الإرسال…" : "أرسل دعاءك"}
       </Button>
     </form>
   );

--- a/apps/web/src/features/share/store.ts
+++ b/apps/web/src/features/share/store.ts
@@ -1,13 +1,21 @@
 import { create } from "zustand";
 
+type ShareView = "form" | "success";
+
 type ShareModalState = {
   isOpen: boolean;
+  view: ShareView;
   open: () => void;
   close: () => void;
+  showSuccess: () => void;
+  reset: () => void;
 };
 
 export const useShareModal = create<ShareModalState>((set) => ({
   isOpen: false,
-  open: () => set({ isOpen: true }),
+  view: "form",
+  open: () => set({ isOpen: true, view: "form" }),
   close: () => set({ isOpen: false }),
+  showSuccess: () => set({ view: "success" }),
+  reset: () => set({ view: "form" }),
 }));

--- a/apps/web/src/features/share/useSubmitPrayer.ts
+++ b/apps/web/src/features/share/useSubmitPrayer.ts
@@ -1,0 +1,9 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { submitPrayer, type SubmitPrayerInput } from "./api";
+
+export const useSubmitPrayer = () =>
+  useMutation({
+    mutationFn: (input: SubmitPrayerInput) => submitPrayer(input),
+  });

--- a/apps/web/src/shared/api/axios.ts
+++ b/apps/web/src/shared/api/axios.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+const baseURL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/v1";
+
+export const api = axios.create({
+  baseURL,
+  headers: { "Content-Type": "application/json" },
+});
+
+export const apiGet = async <T>(
+  url: string,
+  params?: Record<string, unknown>,
+): Promise<T> => {
+  const response = await api.get<T>(url, { params });
+  return response.data;
+};
+
+export const apiPost = async <T>(url: string, body?: unknown): Promise<T> => {
+  const response = await api.post<T>(url, body);
+  return response.data;
+};

--- a/apps/web/src/shared/api/errors.ts
+++ b/apps/web/src/shared/api/errors.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+export type ApiErrorCode = "rate_limited" | "validation_error" | "unknown";
+
+export type ApiError = {
+  code: ApiErrorCode;
+  message: string;
+  status?: number;
+};
+
+type ApiErrorPayload = {
+  error?: { code?: string; message?: string };
+};
+
+export const toApiError = (error: unknown): ApiError => {
+  if (axios.isAxiosError(error)) {
+    const payload = error.response?.data as ApiErrorPayload | undefined;
+    const code = payload?.error?.code;
+    return {
+      code:
+        code === "rate_limited" || code === "validation_error"
+          ? code
+          : "unknown",
+      message: payload?.error?.message ?? error.message,
+      status: error.response?.status,
+    };
+  }
+  return { code: "unknown", message: "حدث خطأ غير متوقع" };
+};

--- a/apps/web/src/shared/api/query-client.ts
+++ b/apps/web/src/shared/api/query-client.ts
@@ -1,0 +1,25 @@
+import {
+  QueryClient,
+  defaultShouldDehydrateQuery,
+  isServer,
+} from "@tanstack/react-query";
+
+const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { staleTime: 60_000 },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
+      },
+    },
+  });
+
+let browserQueryClient: QueryClient | undefined;
+
+export const getQueryClient = (): QueryClient => {
+  if (isServer) return makeQueryClient();
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+};


### PR DESCRIPTION
## Summary
Wires `apps/web` to the live API: data layer (TanStack Query + hydration + axios), the hero (random confirmed prayer + category), the our-prayers marquee (latest confirmed prayers, diacritized), and the share form (POST /prayers with success + 429 handling). Adds `textDiacritized` to the API Prayer response.

## Notes
- Page is `force-dynamic`; SSR prefetch + HydrationBoundary -> no loading flash. Graceful static fallback when the API is unreachable.
- `NEXT_PUBLIC_API_URL` is build-time baked; web Dockerfile now declares the ARG/ENV and the Coolify build env is set to `https://api.ad3oni.com/v1`.
- Verified locally against the live API: hero + marquee render real confirmed prayers; build/lint/tsc/pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)