### PR TITLE
feat(api): rework prayer schema + diacritization (integrity-guarded, partial)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.4"
+version = "0.1.5"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/scripts/apply_pb_schema.py
+++ b/apps/api/scripts/apply_pb_schema.py
@@ -7,8 +7,6 @@ from src.shared.arabic.normalize import normalize_arabic
 from src.shared.config.settings import get_settings
 
 _PRAYER_TEXT_FIELDS = [
-    "text_original",
-    "text_diacritized",
     "normalized",
     "text_hash",
     "rejection_reason",
@@ -67,15 +65,6 @@ async def _migrate_prayers(http: httpx.AsyncClient, base: str, headers: dict[str
 
     if "processed_at" not in names:
         fields.append({"name": "processed_at", "type": "date", "required": False, "hidden": False})
-    if "diacritization_confidence" not in names:
-        fields.append(
-            {
-                "name": "diacritization_confidence",
-                "type": "number",
-                "required": False,
-                "hidden": False,
-            }
-        )
     if "duplicate_of" not in names:
         fields.append(
             {

--- a/apps/api/scripts/reset_prayers.py
+++ b/apps/api/scripts/reset_prayers.py
@@ -1,0 +1,85 @@
+import asyncio
+import json
+from typing import Any
+
+import httpx
+from src.shared.config.settings import get_settings
+
+_REMOVED_FIELDS = ("text_original", "text_diacritized", "diacritization_confidence")
+
+
+async def _authenticate(
+    http: httpx.AsyncClient, base: str, email: str, password: str
+) -> dict[str, str]:
+    response = await http.post(
+        f"{base}/api/collections/_superusers/auth-with-password",
+        json={"identity": email, "password": password},
+    )
+    response.raise_for_status()
+    return {"Authorization": response.json()["token"]}
+
+
+async def _delete_all_prayers(
+    http: httpx.AsyncClient, base: str, headers: dict[str, str]
+) -> None:
+    deleted = 0
+    while True:
+        response = await http.get(
+            f"{base}/api/collections/prayers/records",
+            headers=headers,
+            params={"perPage": 200, "page": 1, "skipTotal": True},
+        )
+        response.raise_for_status()
+        items = response.json().get("items", [])
+        if not items:
+            break
+        for item in items:
+            removal = await http.delete(
+                f"{base}/api/collections/prayers/records/{item['id']}",
+                headers=headers,
+            )
+            removal.raise_for_status()
+            deleted += 1
+    print(f"deleted {deleted} prayers")
+
+
+async def _drop_fields(
+    http: httpx.AsyncClient, base: str, headers: dict[str, str]
+) -> None:
+    response = await http.get(f"{base}/api/collections/prayers", headers=headers)
+    response.raise_for_status()
+    collection: dict[str, Any] = response.json()
+    print(json.dumps(collection, ensure_ascii=False, indent=2))
+
+    fields = [
+        field
+        for field in collection["fields"]
+        if field["name"] not in _REMOVED_FIELDS
+    ]
+    indexes: list[str] = collection.get("indexes", [])
+
+    patch = await http.patch(
+        f"{base}/api/collections/{collection['id']}",
+        headers=headers,
+        json={"fields": fields, "indexes": indexes},
+    )
+    patch.raise_for_status()
+    print("dropped fields:", ", ".join(_REMOVED_FIELDS))
+
+
+async def main() -> None:
+    settings = get_settings()
+    base = settings.pocketbase_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=60.0) as http:
+        headers = await _authenticate(
+            http,
+            base,
+            settings.pocketbase_admin_email,
+            settings.pocketbase_admin_password,
+        )
+        await _delete_all_prayers(http, base, headers)
+        await _drop_fields(http, base, headers)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/api/src/features/ingestion/agents/categorize.py
+++ b/apps/api/src/features/ingestion/agents/categorize.py
@@ -11,7 +11,7 @@ from src.shared.queue.context import WorkerContext
 _TAXONOMY_PAGE_SIZE = 200
 _FALLBACK_GROUP = "أدعية عامة"
 _FALLBACK_CATEGORY = "أدعية متنوعة"
-_FALLBACK_TYPE = "دعاء"
+_FALLBACK_TYPE = "مخصص"
 
 
 async def _names(context: WorkerContext, collection: str) -> list[str]:

--- a/apps/api/src/features/ingestion/agents/diacritize.py
+++ b/apps/api/src/features/ingestion/agents/diacritize.py
@@ -1,15 +1,53 @@
-from src.features.ingestion.prompts import DIACRITIZATION_SYSTEM, diacritization_user
+from src.features.ingestion.prompts import (
+    DIACRITIZATION_VERIFY_SYSTEM,
+    diacritization_system,
+    diacritization_user,
+    diacritization_verify_user,
+)
 from src.features.ingestion.schema import DiacritizationResult
 from src.shared.ai.structured import complete_json
+from src.shared.arabic.normalize import harakat_preserves_wording
+from src.shared.logging.setup import get_logger
 from src.shared.queue.context import WorkerContext
 
+logger = get_logger("api.ingestion")
 
-async def diacritize(context: WorkerContext, text: str) -> DiacritizationResult:
-    return await complete_json(
+
+async def _add_harakat(context: WorkerContext, corrected: str) -> str:
+    result = await complete_json(
         context.ai,
         context.settings.ai_model,
-        DIACRITIZATION_SYSTEM,
-        diacritization_user(text),
+        diacritization_system(context.settings.diacritization_mode),
+        diacritization_user(corrected),
         DiacritizationResult,
         reasoning_effort=context.settings.diacritization_effort,
     )
+    return result.diacritized_text.strip()
+
+
+async def _verify_harakat(
+    context: WorkerContext, corrected: str, diacritized: str
+) -> str:
+    result = await complete_json(
+        context.ai,
+        context.settings.ai_model,
+        DIACRITIZATION_VERIFY_SYSTEM,
+        diacritization_verify_user(corrected, diacritized),
+        DiacritizationResult,
+        reasoning_effort=context.settings.diacritization_effort,
+    )
+    candidate = result.diacritized_text.strip()
+    if candidate and harakat_preserves_wording(corrected, candidate):
+        return candidate
+    return diacritized
+
+
+async def diacritize(context: WorkerContext, corrected: str) -> str:
+    for _ in range(context.settings.diacritization_max_attempts):
+        candidate = await _add_harakat(context, corrected)
+        if candidate and harakat_preserves_wording(corrected, candidate):
+            if context.settings.diacritization_verify_enabled:
+                return await _verify_harakat(context, corrected, candidate)
+            return candidate
+    logger.info("diacritization_fallback_plain")
+    return corrected

--- a/apps/api/src/features/ingestion/finalize.py
+++ b/apps/api/src/features/ingestion/finalize.py
@@ -48,8 +48,6 @@ async def finalize_confirmed(
     prayer_id: str,
     *,
     text: str,
-    diacritized: str,
-    confidence: float,
     outcome: DuplicateOutcome,
     category_id: str,
     type_id: str,
@@ -60,14 +58,12 @@ async def finalize_confirmed(
         {
             "status": "confirmed",
             "text": text,
-            "text_diacritized": diacritized,
             "normalized": outcome.normalized,
             "text_hash": outcome.text_hash,
             "category": category_id,
             "type": type_id,
             "ai_model": context.settings.ai_model,
             "processed_at": _timestamp(),
-            "diacritization_confidence": confidence,
         },
     )
 

--- a/apps/api/src/features/ingestion/pipeline.py
+++ b/apps/api/src/features/ingestion/pipeline.py
@@ -21,16 +21,16 @@ async def run_pipeline(context: WorkerContext, prayer_id: str) -> None:
         logger.info("prayer_skipped id=%s reason=not_claimable", prayer_id)
         return
 
-    original_text = claimed.get("text_original") or claimed.get("text") or ""
+    source_text = claimed.get("text") or ""
 
-    compliance = await review_compliance(context, original_text)
+    compliance = await review_compliance(context, source_text)
     if not compliance.compliant:
         await finalize_rejected(context, prayer_id, compliance.violation_type, compliance.reason)
         logger.info("prayer_rejected id=%s violation=%s", prayer_id, compliance.violation_type)
         return
 
-    spelling = await correct_spelling(context, original_text)
-    corrected = spelling.corrected_text.strip() or original_text
+    spelling = await correct_spelling(context, source_text)
+    corrected = spelling.corrected_text.strip() or source_text
 
     duplicate = await find_duplicate(context, corrected)
     if duplicate.duplicate_of_id is not None:
@@ -38,15 +38,13 @@ async def run_pipeline(context: WorkerContext, prayer_id: str) -> None:
         logger.info("prayer_duplicate id=%s of=%s", prayer_id, duplicate.duplicate_of_id)
         return
 
-    diacritization = await diacritize(context, corrected)
+    text = await diacritize(context, corrected)
     category = await categorize(context, corrected)
 
     await finalize_confirmed(
         context,
         prayer_id,
-        text=corrected,
-        diacritized=diacritization.diacritized_text,
-        confidence=diacritization.confidence,
+        text=text,
         outcome=duplicate,
         category_id=category.category_id,
         type_id=category.type_id,

--- a/apps/api/src/features/ingestion/prompts.py
+++ b/apps/api/src/features/ingestion/prompts.py
@@ -29,21 +29,44 @@ DEDUP_SYSTEM = (
     "set is_duplicate to false and duplicate_index to null."
 )
 
-DIACRITIZATION_SYSTEM = (
-    "You add full, correct Arabic diacritics (tashkil) to a supplication, the way a "
-    "vocalized Mushaf or du'a book would. Add harakat at the word level following correct "
-    "Arabic grammar, keep the wording exactly as given, and change nothing but the "
-    "diacritics. Return the diacritized text in diacritized_text and a confidence between "
-    "0 and 1 reflecting how certain you are of the vocalization."
+DIACRITIZATION_PARTIAL_SYSTEM = (
+    "You add selective Arabic diacritics (tashkil) to a supplication so it reads correctly. "
+    "Add harakat ONLY where they are needed to remove ambiguity or prevent a misreading: an "
+    "ambiguous verb voice or mood, a case ending that changes the meaning, or a word a fluent "
+    "reader could otherwise misread. Leave obvious and unambiguous letters bare. You MUST NOT "
+    "add, drop, reorder, or change any word or letter, including conjunctions such as وَ; change "
+    "nothing but the harakat. Return only the Arabic text in diacritized_text."
 )
+
+DIACRITIZATION_FULL_SYSTEM = (
+    "You add full, correct Arabic diacritics (tashkil) to a supplication, the way a vocalized "
+    "Mushaf or du'a book would. Add harakat at the word level following correct Arabic grammar. "
+    "You MUST NOT add, drop, reorder, or change any word or letter, including conjunctions such "
+    "as وَ; change nothing but the harakat. Return only the Arabic text in diacritized_text."
+)
+
+DIACRITIZATION_VERIFY_SYSTEM = (
+    "You are given a supplication in plain Arabic (the authoritative wording) and a "
+    "diacritized version of it. Review the harakat and fix any that are grammatically "
+    "wrong or that misvocalize a word, keeping the diacritization selective. You MUST keep "
+    "the exact same words and letters as the plain version, including every conjunction; "
+    "change nothing but the harakat. Return the corrected text in diacritized_text."
+)
+
+
+def diacritization_system(mode: str) -> str:
+    return DIACRITIZATION_FULL_SYSTEM if mode == "full" else DIACRITIZATION_PARTIAL_SYSTEM
+
 
 CATEGORIZATION_SYSTEM = (
     "You organize Arabic supplications into a taxonomy with three levels: group (broad "
     "theme), category (specific topic), and type (the kind of supplication). You are given "
-    "the supplication and the existing taxonomy. Reuse an existing name verbatim whenever "
-    "one fits the supplication. Only when nothing fits, propose a concise new Arabic name "
-    "(two or three words). Always return an Arabic name for group_name, category_name, and "
-    "type_name."
+    "the supplication and the existing taxonomy. Always return a non-empty Arabic name for "
+    "group_name, category_name, and type_name. Reuse an existing group, category, or type "
+    "name verbatim whenever one fits. Only when nothing fits, propose a concise new Arabic "
+    "name (two or three words) for the category and its group. For type_name return the "
+    "kind of supplication when you are confident; when you are unsure, return the existing "
+    "type مخصص."
 )
 
 
@@ -62,6 +85,10 @@ def dedup_user(text: str, candidates: list[str]) -> str:
 
 def diacritization_user(text: str) -> str:
     return f"الدعاء:\n{text}"
+
+
+def diacritization_verify_user(corrected: str, diacritized: str) -> str:
+    return f"النص الصحيح:\n{corrected}\n\nالنص المشكّل:\n{diacritized}"
 
 
 def categorization_user(

--- a/apps/api/src/features/ingestion/schema.py
+++ b/apps/api/src/features/ingestion/schema.py
@@ -20,7 +20,6 @@ class DedupJudgeResult(BaseModel):
 
 class DiacritizationResult(BaseModel):
     diacritized_text: str
-    confidence: float
 
 
 class CategorizationResult(BaseModel):

--- a/apps/api/src/features/prayers/mappers.py
+++ b/apps/api/src/features/prayers/mappers.py
@@ -11,7 +11,6 @@ def to_prayer(record: dict[str, Any]) -> Prayer:
     return Prayer(
         id=record["id"],
         text=record["text"],
-        text_diacritized=record.get("text_diacritized"),
         status=record["status"],
         category=to_category(category_record) if category_record else None,
         type=to_prayer_type(type_record) if type_record else None,

--- a/apps/api/src/features/prayers/schema.py
+++ b/apps/api/src/features/prayers/schema.py
@@ -18,7 +18,6 @@ TaxonomySlug = Annotated[
 class Prayer(CamelModel):
     id: str
     text: str
-    text_diacritized: str | None = None
     status: str
     category: Category | None = None
     type: PrayerType | None = None

--- a/apps/api/src/features/prayers/service.py
+++ b/apps/api/src/features/prayers/service.py
@@ -90,7 +90,6 @@ class PrayerService:
 
     async def submit_prayer(self, submission: PrayerSubmission) -> SubmittedPrayer:
         payload: dict[str, Any] = {
-            "text_original": submission.text,
             "text": submission.text,
             "status": "pending",
         }

--- a/apps/api/src/shared/arabic/normalize.py
+++ b/apps/api/src/shared/arabic/normalize.py
@@ -39,3 +39,7 @@ def normalize_arabic(text: str) -> str:
     folded = fold_letters(stripped)
     letters_only = _NON_ARABIC.sub(" ", folded)
     return _WHITESPACE.sub(" ", letters_only).strip()
+
+
+def harakat_preserves_wording(source: str, diacritized: str) -> bool:
+    return normalize_arabic(source) == normalize_arabic(diacritized)

--- a/apps/api/src/shared/config/settings.py
+++ b/apps/api/src/shared/config/settings.py
@@ -43,6 +43,10 @@ class Settings(BaseSettings):
     diacritization_effort: str = "medium"
     categorization_effort: str = "medium"
 
+    diacritization_mode: Literal["partial", "full"] = "partial"
+    diacritization_max_attempts: int = 2
+    diacritization_verify_enabled: bool = True
+
     worker_max_jobs: int = 1
     job_max_tries: int = 3
     job_timeout: int = 120

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -17,8 +17,7 @@ CATEGORY: dict[str, Any] = {
 PRAYER_TYPE: dict[str, Any] = {"id": "t1", "name": "نبوي", "slug": "prophetic"}
 PRAYER: dict[str, Any] = {
     "id": "p1",
-    "text": "اللهم اغفر لي وارحمني",
-    "text_diacritized": "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي",
+    "text": "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي",
     "status": "confirmed",
     "created": "2026-05-30 00:00:00.000Z",
     "updated": "2026-05-30 00:00:00.000Z",

--- a/apps/api/tests/test_arabic.py
+++ b/apps/api/tests/test_arabic.py
@@ -1,5 +1,9 @@
 from src.shared.arabic.hashing import text_hash
-from src.shared.arabic.normalize import normalize_arabic, strip_tashkil
+from src.shared.arabic.normalize import (
+    harakat_preserves_wording,
+    normalize_arabic,
+    strip_tashkil,
+)
 from src.shared.arabic.slugify import slugify_arabic
 
 
@@ -35,3 +39,15 @@ def test_slugify_produces_ascii_slug() -> None:
 def test_slugify_falls_back_when_no_letters() -> None:
     slug = slugify_arabic("123 !!!")
     assert slug.startswith("item-")
+
+
+def test_harakat_preserves_wording_accepts_harakat_only_change() -> None:
+    source = "اللهم اجعل القران العظيم ربيع قلوبنا ونور صدورنا"
+    diacritized = "اللَّهُمَّ اجْعَلِ الْقُرْآنَ الْعَظِيمَ رَبِيعَ قُلُوبِنَا وَنُورَ صُدُورِنَا"
+    assert harakat_preserves_wording(source, diacritized) is True
+
+
+def test_harakat_preserves_wording_rejects_dropped_word() -> None:
+    source = "ربيع قلوبنا ونور صدورنا"
+    mutated = "ربيعا قلوبنا نورا صدورنا"
+    assert harakat_preserves_wording(source, mutated) is False

--- a/apps/api/tests/test_prayers.py
+++ b/apps/api/tests/test_prayers.py
@@ -9,7 +9,7 @@ def test_list_prayers_returns_paginated_envelope(client: TestClient) -> None:
     assert body["perPage"] == 20
     prayer = body["items"][0]
     assert prayer["status"] == "confirmed"
-    assert prayer["textDiacritized"] == "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي"
+    assert prayer["text"] == "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي"
     assert prayer["category"]["group"]["slug"] == "emotion"
     assert prayer["type"]["slug"] == "prophetic"
 
@@ -33,7 +33,7 @@ def test_random_prayer(client: TestClient) -> None:
 def test_get_prayer_by_id(client: TestClient) -> None:
     response = client.get("/v1/prayers/p1")
     assert response.status_code == 200
-    assert response.json()["text"] == "اللهم اغفر لي وارحمني"
+    assert response.json()["text"] == "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي"
 
 
 def test_submit_prayer_creates_pending(client: TestClient) -> None:
@@ -47,7 +47,8 @@ def test_submit_prayer_creates_pending(client: TestClient) -> None:
     submitted = client.fake.created[0]  # type: ignore[attr-defined]
     assert submitted["status"] == "pending"
     assert submitted["category"] == "c1"
-    assert submitted["text_original"] == "اللهم ارزقني الصبر"
+    assert submitted["text"] == "اللهم ارزقني الصبر"
+    assert "text_original" not in submitted
     jobs = client.queue.jobs  # type: ignore[attr-defined]
     assert jobs == [("process_prayer", ("new1",))]
 

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.4"
+version = "0.1.5"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/src/features/landing/components/Hero.tsx
+++ b/apps/web/src/features/landing/components/Hero.tsx
@@ -24,7 +24,7 @@ export const Hero = () => {
   const reduceMotion = useReducedMotion();
   const { data: prayer } = useQuery(randomPrayerQueryOptions());
 
-  const prayerText = prayer?.textDiacritized ?? prayer?.text ?? dailyPrayer.text;
+  const prayerText = prayer?.text ?? dailyPrayer.text;
   const prayerLabel = prayer?.category?.name ?? dailyPrayer.attribution;
 
   return (

--- a/apps/web/src/features/landing/components/PrayerMarquee.tsx
+++ b/apps/web/src/features/landing/components/PrayerMarquee.tsx
@@ -9,7 +9,7 @@ import { PrayerCard } from "./PrayerCard";
 
 const toCard = (prayer: Prayer): CommunityPrayer => ({
   id: prayer.id,
-  text: prayer.textDiacritized ?? prayer.text,
+  text: prayer.text,
   category: prayer.category?.name ?? "",
 });
 

--- a/apps/web/src/features/prayers/types.ts
+++ b/apps/web/src/features/prayers/types.ts
@@ -20,7 +20,6 @@ export type PrayerType = {
 export type Prayer = {
   id: string;
   text: string;
-  textDiacritized?: string | null;
   status: string;
   category?: Category | null;
   type?: PrayerType | null;


### PR DESCRIPTION
## Summary
Reworks the prayer model and diacritization per owner feedback.

- `text` IS the final diacritized du'a; `normalized` is its script fold. Removed `text_original`, `text_diacritized`, `diacritization_confidence`.
- **Selective/partial** diacritization with a **hard integrity guard**: after the AI adds harakat, the de-diacritized output must normalize identically to the corrected source, else retry, else fall back to plain text. The wording can never change (fixes the dropped-`و` bug). Plus an AI verify/correct-harakat pass (default on).
- Category and type are never empty (type unsure -> existing `مخصص`).
- `scripts/reset_prayers.py` wipes all prayer records and drops the 3 columns; `apply_pb_schema.py` no longer re-adds them. Run after deploy.
- Web reads plain `prayer.text`.

## Verification
ruff + mypy + 29 pytest green (incl. a new integrity-guard unit test using the real `ربيع قلوبنا ونور صدورنا` regression); web lint/tsc/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)