### PR TITLE
feat(api): daily prayer route with duplicate-weighted Redis rotation

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.6"
+version = "0.1.7"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/scripts/reset_daily.py
+++ b/apps/api/scripts/reset_daily.py
@@ -1,0 +1,23 @@
+import asyncio
+from collections.abc import Awaitable
+from typing import cast
+
+from src.features.daily.keys import DAILY_CURRENT, DAILY_DATE, DAILY_HISTORY
+from src.shared.config.settings import get_settings
+from src.shared.queue.pool import create_arq_pool
+
+
+async def main() -> None:
+    settings = get_settings()
+    redis = await create_arq_pool(settings)
+    try:
+        removed = await cast(
+            "Awaitable[int]", redis.delete(DAILY_CURRENT, DAILY_HISTORY, DAILY_DATE)
+        )
+        print(f"cleared {removed} daily key(s): current, history, date")
+    finally:
+        await redis.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/api/src/features/daily/keys.py
+++ b/apps/api/src/features/daily/keys.py
@@ -1,0 +1,5 @@
+DAILY_CURRENT = "ad3oni:daily:current"
+DAILY_HISTORY = "ad3oni:daily:history"
+DAILY_DATE = "ad3oni:daily:date"
+
+MECCA_TIMEZONE = "Asia/Riyadh"

--- a/apps/api/src/features/daily/router.py
+++ b/apps/api/src/features/daily/router.py
@@ -1,0 +1,21 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from src.features.daily.service import DailyService
+from src.features.prayers.schema import Prayer
+from src.shared.dependencies import PocketBaseDep, RedisDep
+
+router = APIRouter(prefix="/daily", tags=["daily"])
+
+
+def get_daily_service(pocketbase: PocketBaseDep, redis: RedisDep) -> DailyService:
+    return DailyService(pocketbase, redis)
+
+
+DailyServiceDep = Annotated[DailyService, Depends(get_daily_service)]
+
+
+@router.get("", response_model=Prayer)
+async def daily_prayer(service: DailyServiceDep) -> Prayer:
+    return await service.get_daily()

--- a/apps/api/src/features/daily/selection.py
+++ b/apps/api/src/features/daily/selection.py
@@ -1,0 +1,111 @@
+import random
+from collections import Counter
+from collections.abc import Awaitable
+from datetime import datetime
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+from arq import ArqRedis
+
+from src.features.daily.keys import (
+    DAILY_CURRENT,
+    DAILY_DATE,
+    DAILY_HISTORY,
+    MECCA_TIMEZONE,
+)
+from src.shared.pocketbase.client import PocketBaseClient
+
+_PAGE_SIZE = 500
+
+
+def _decode(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+async def _collect_records(
+    pocketbase: PocketBaseClient, filter_: str
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = await pocketbase.list_records(
+            "prayers",
+            {
+                "filter": filter_,
+                "page": page,
+                "perPage": _PAGE_SIZE,
+                "skipTotal": True,
+                "fields": "id,duplicate_of",
+            },
+        )
+        items = data.get("items", [])
+        records.extend(items)
+        if len(items) < _PAGE_SIZE:
+            return records
+        page += 1
+
+
+async def _duplicate_counts(pocketbase: PocketBaseClient) -> Counter[str]:
+    duplicates = await _collect_records(pocketbase, 'status = "duplicate"')
+    return Counter(
+        record["duplicate_of"]
+        for record in duplicates
+        if record.get("duplicate_of")
+    )
+
+
+async def _history(redis: ArqRedis) -> set[str]:
+    members = await cast("Awaitable[set[bytes]]", redis.smembers(DAILY_HISTORY))
+    return {decoded for member in members if (decoded := _decode(member))}
+
+
+def _pick_from_tier(eligible: list[str], counts: Counter[str]) -> str:
+    peak = max(counts.get(prayer_id, 0) for prayer_id in eligible)
+    tier = [prayer_id for prayer_id in eligible if counts.get(prayer_id, 0) == peak]
+    return random.choice(tier)
+
+
+async def select_daily_prayer_id(
+    pocketbase: PocketBaseClient, redis: ArqRedis
+) -> str | None:
+    confirmed = [
+        record["id"]
+        for record in await _collect_records(pocketbase, 'status = "confirmed"')
+    ]
+    if not confirmed:
+        return None
+
+    counts = await _duplicate_counts(pocketbase)
+    history = await _history(redis)
+
+    eligible = [prayer_id for prayer_id in confirmed if prayer_id not in history]
+    if not eligible:
+        await cast("Awaitable[int]", redis.delete(DAILY_HISTORY))
+        current = _decode(await redis.get(DAILY_CURRENT))
+        eligible = [prayer_id for prayer_id in confirmed if prayer_id != current]
+        if not eligible:
+            eligible = confirmed
+
+    return _pick_from_tier(eligible, counts)
+
+
+async def assign_daily_prayer(
+    pocketbase: PocketBaseClient, redis: ArqRedis
+) -> str | None:
+    prayer_id = await select_daily_prayer_id(pocketbase, redis)
+    if prayer_id is None:
+        return None
+
+    today = datetime.now(ZoneInfo(MECCA_TIMEZONE)).date().isoformat()
+    await redis.set(DAILY_CURRENT, prayer_id)
+    await cast("Awaitable[int]", redis.sadd(DAILY_HISTORY, prayer_id))
+    await redis.set(DAILY_DATE, today)
+    return prayer_id
+
+
+async def current_daily_prayer_id(redis: ArqRedis) -> str | None:
+    return _decode(await redis.get(DAILY_CURRENT))

--- a/apps/api/src/features/daily/service.py
+++ b/apps/api/src/features/daily/service.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+from arq import ArqRedis
+
+from src.features.daily.selection import (
+    assign_daily_prayer,
+    current_daily_prayer_id,
+)
+from src.features.prayers.mappers import to_prayer
+from src.features.prayers.schema import Prayer
+from src.shared.errors.exceptions import NotFoundError
+from src.shared.pocketbase.client import PocketBaseClient
+from src.shared.pocketbase.filters import combine, quote
+
+_CONFIRMED = 'status = "confirmed"'
+_PRAYER_EXPAND = "category.group,type"
+
+
+class DailyService:
+    def __init__(self, pocketbase: PocketBaseClient, redis: ArqRedis) -> None:
+        self._pocketbase = pocketbase
+        self._redis = redis
+
+    async def get_daily(self) -> Prayer:
+        prayer_id = await current_daily_prayer_id(self._redis)
+        if prayer_id is None:
+            prayer_id = await assign_daily_prayer(self._pocketbase, self._redis)
+
+        record = await self._fetch(prayer_id)
+        if record is None:
+            prayer_id = await assign_daily_prayer(self._pocketbase, self._redis)
+            record = await self._fetch(prayer_id)
+
+        if record is None:
+            raise NotFoundError("No prayers available")
+        return to_prayer(record)
+
+    async def _fetch(self, prayer_id: str | None) -> dict[str, Any] | None:
+        if prayer_id is None:
+            return None
+        return await self._pocketbase.get_first(
+            "prayers",
+            combine(_CONFIRMED, f"id = {quote(prayer_id)}"),
+            expand=_PRAYER_EXPAND,
+        )

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from src.features.daily.router import router as daily_router
 from src.features.health.router import router as health_router
 from src.features.prayers.router import router as prayers_router
 from src.features.taxonomy.router import router as taxonomy_router
@@ -26,6 +27,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(taxonomy_router, prefix=API_PREFIX)
     app.include_router(prayers_router, prefix=API_PREFIX)
+    app.include_router(daily_router, prefix=API_PREFIX)
 
     return app
 

--- a/apps/api/src/shared/dependencies.py
+++ b/apps/api/src/shared/dependencies.py
@@ -16,5 +16,10 @@ def get_queue(request: Request) -> ArqRedis:
     return queue
 
 
+def get_redis(request: Request) -> ArqRedis:
+    return get_queue(request)
+
+
 PocketBaseDep = Annotated[PocketBaseClient, Depends(get_pocketbase)]
 QueueDep = Annotated[ArqRedis, Depends(get_queue)]
+RedisDep = Annotated[ArqRedis, Depends(get_redis)]

--- a/apps/api/src/shared/queue/settings.py
+++ b/apps/api/src/shared/queue/settings.py
@@ -1,7 +1,11 @@
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import httpx
+from arq import ArqRedis, cron
 
+from src.features.daily.keys import MECCA_TIMEZONE
+from src.features.daily.selection import assign_daily_prayer
 from src.features.ingestion.finalize import finalize_failed
 from src.features.ingestion.pipeline import run_pipeline
 from src.shared.ai.client import create_ai_client
@@ -54,8 +58,20 @@ async def process_prayer(ctx: dict[Any, Any], prayer_id: str) -> None:
         raise
 
 
+async def assign_daily(ctx: dict[Any, Any]) -> None:
+    context = get_worker_context(ctx)
+    redis: ArqRedis = ctx["redis"]
+    try:
+        prayer_id = await assign_daily_prayer(context.pocketbase, redis)
+        logger.info("daily_prayer_assigned id=%s", prayer_id)
+    except Exception:
+        logger.exception("daily_prayer_assignment_failed")
+
+
 class WorkerSettings:
     functions = [process_prayer]
+    cron_jobs = [cron(assign_daily, hour=0, minute=0, run_at_startup=False)]
+    timezone = ZoneInfo(MECCA_TIMEZONE)
     on_startup = startup
     on_shutdown = shutdown
     redis_settings = redis_settings_from(_settings)

--- a/apps/api/tests/test_daily.py
+++ b/apps/api/tests/test_daily.py
@@ -1,0 +1,197 @@
+import asyncio
+import re
+from collections.abc import Iterator
+from typing import Any, cast
+
+import pytest
+from arq import ArqRedis
+from fastapi.testclient import TestClient
+from src.features.daily.keys import DAILY_CURRENT, DAILY_HISTORY
+from src.features.daily.selection import assign_daily_prayer, select_daily_prayer_id
+from src.main import create_app
+from src.shared.dependencies import get_pocketbase, get_redis
+from src.shared.pocketbase.client import PocketBaseClient
+from src.shared.ratelimit.limiter import limiter
+
+BytesSet = set[bytes]
+
+GROUP: dict[str, Any] = {"id": "g1", "name": "المشاعر", "slug": "emotion"}
+CATEGORY: dict[str, Any] = {
+    "id": "c1",
+    "name": "القلق والهمّ",
+    "slug": "anxiety",
+    "expand": {"group": GROUP},
+}
+PRAYER_TYPE: dict[str, Any] = {"id": "t1", "name": "نبوي", "slug": "prophetic"}
+
+_ID_PATTERN = re.compile(r'id = "([^"]+)"')
+
+
+def _confirmed(prayer_id: str) -> dict[str, Any]:
+    return {
+        "id": prayer_id,
+        "text": "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي",
+        "status": "confirmed",
+        "created": "2026-05-30 00:00:00.000Z",
+        "updated": "2026-05-30 00:00:00.000Z",
+        "expand": {"category": CATEGORY, "type": PRAYER_TYPE},
+    }
+
+
+class FakePocketBase:
+    def __init__(
+        self,
+        confirmed_ids: list[str],
+        duplicate_of: list[str] | None = None,
+    ) -> None:
+        self.confirmed = [_confirmed(prayer_id) for prayer_id in confirmed_ids]
+        self.duplicates = [
+            {"id": f"d{index}", "status": "duplicate", "duplicate_of": target}
+            for index, target in enumerate(duplicate_of or [])
+        ]
+
+    async def list_records(
+        self, collection: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        filter_ = (params or {}).get("filter", "")
+        if 'status = "duplicate"' in filter_:
+            items = self.duplicates
+        elif 'status = "confirmed"' in filter_:
+            items = self.confirmed
+        else:
+            items = []
+        return {
+            "items": items,
+            "page": 1,
+            "perPage": 500,
+            "totalItems": len(items),
+            "totalPages": 1,
+        }
+
+    async def get_first(
+        self, collection: str, filter_: str, *, expand: str | None = None
+    ) -> dict[str, Any] | None:
+        match = _ID_PATTERN.search(filter_)
+        if match is None:
+            return None
+        prayer_id = match.group(1)
+        return next(
+            (record for record in self.confirmed if record["id"] == prayer_id), None
+        )
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.sets: dict[str, set[str]] = {}
+
+    async def get(self, key: str) -> bytes | None:
+        value = self.values.get(key)
+        return value.encode() if value is not None else None
+
+    async def set(self, key: str, value: str) -> None:
+        self.values[key] = value
+
+    async def sadd(self, key: str, *members: str) -> None:
+        self.sets.setdefault(key, set()).update(members)
+
+    async def smembers(self, key: str) -> BytesSet:
+        return {member.encode() for member in self.sets.get(key, set())}
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            removed += self.values.pop(key, None) is not None
+            removed += self.sets.pop(key, None) is not None
+        return removed
+
+
+def _select(pocketbase: FakePocketBase, redis: FakeRedis) -> str | None:
+    return asyncio.run(
+        select_daily_prayer_id(
+            cast(PocketBaseClient, pocketbase), cast(ArqRedis, redis)
+        )
+    )
+
+
+def _assign(pocketbase: FakePocketBase, redis: FakeRedis) -> str | None:
+    return asyncio.run(
+        assign_daily_prayer(cast(PocketBaseClient, pocketbase), cast(ArqRedis, redis))
+    )
+
+
+def _make_client(pocketbase: FakePocketBase, redis: FakeRedis) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_pocketbase] = lambda: pocketbase
+    app.dependency_overrides[get_redis] = lambda: redis
+    limiter.enabled = False
+    return TestClient(app)
+
+
+@pytest.fixture
+def cleanup() -> Iterator[None]:
+    yield
+    limiter.enabled = True
+
+
+def test_daily_cold_start_assigns_and_returns_prayer(cleanup: None) -> None:
+    pocketbase = FakePocketBase(["p1"])
+    redis = FakeRedis()
+    with _make_client(pocketbase, redis) as client:
+        response = client.get("/v1/daily")
+    assert response.status_code == 200
+    assert response.json()["id"] == "p1"
+    assert redis.values[DAILY_CURRENT] == "p1"
+    assert redis.sets[DAILY_HISTORY] == {"p1"}
+
+
+def test_daily_is_stable_across_calls(cleanup: None) -> None:
+    pocketbase = FakePocketBase(["p1", "p2"], duplicate_of=["p1", "p1", "p1"])
+    redis = FakeRedis()
+    redis.values[DAILY_CURRENT] = "p2"
+    with _make_client(pocketbase, redis) as client:
+        first = client.get("/v1/daily")
+        second = client.get("/v1/daily")
+    assert first.json()["id"] == "p2"
+    assert second.json()["id"] == "p2"
+
+
+def test_no_prayers_returns_404(cleanup: None) -> None:
+    with _make_client(FakePocketBase([]), FakeRedis()) as client:
+        response = client.get("/v1/daily")
+    assert response.status_code == 404
+
+
+def test_duplicate_weighting_picks_most_duplicated() -> None:
+    pocketbase = FakePocketBase(
+        ["p1", "p2", "p3"], duplicate_of=["p2", "p2", "p2", "p1"]
+    )
+    redis = FakeRedis()
+    for _ in range(20):
+        assert _select(pocketbase, redis) == "p2"
+
+
+def test_selection_skips_history() -> None:
+    pocketbase = FakePocketBase(["p1", "p2", "p3"])
+    redis = FakeRedis()
+    redis.sets[DAILY_HISTORY] = {"p1"}
+    for _ in range(20):
+        assert _select(pocketbase, redis) in {"p2", "p3"}
+
+
+def test_auto_recycle_excludes_current() -> None:
+    pocketbase = FakePocketBase(["p1", "p2"])
+    redis = FakeRedis()
+    redis.sets[DAILY_HISTORY] = {"p1", "p2"}
+    redis.values[DAILY_CURRENT] = "p1"
+    assert _select(pocketbase, redis) == "p2"
+    assert DAILY_HISTORY not in redis.sets
+
+
+def test_assign_writes_current_and_history() -> None:
+    pocketbase = FakePocketBase(["p1"])
+    redis = FakeRedis()
+    prayer_id = _assign(pocketbase, redis)
+    assert prayer_id == "p1"
+    assert redis.values[DAILY_CURRENT] == "p1"
+    assert redis.sets[DAILY_HISTORY] == {"p1"}


### PR DESCRIPTION
## What

Adds a **prayer of the day**: `GET /v1/daily` returns one prayer chosen once per day and served identically to everyone until the next rollover.

## How it picks

- **Duplicate-weighted, not uniform.** Counts how many duplicate submissions point at each confirmed prayer (`duplicate_of`), takes the top tier, and breaks ties randomly. The most-loved du'as surface first.
- **Never repeats.** Every served id is recorded in a Redis set; a prayer can't be picked again until all have had a turn, then the history **auto-recycles** (keeping only the most recent pick excluded so it never repeats back-to-back).
- **Redis-only state** under `ad3oni:daily:*` (`current`, `history`, `date`). Reset the whole cycle with `scripts/reset_daily.py` or a Redis flush. Nothing is stored in PocketBase.
- **Scheduled at midnight Mecca.** An arq `cron(assign_daily, hour=0, minute=0)` with `timezone = Asia/Riyadh` on `WorkerSettings`.
- **Self-healing.** The route cold-start assigns if Redis is empty (fresh deploy / post-flush), so it never 404s; it also reassigns once if the stored pick no longer resolves.

## Scope

API only. New `src/features/daily/` (keys, selection, service, router), `scripts/reset_daily.py`, `tests/test_daily.py`. Wires `get_redis`/`RedisDep`, mounts the router, registers the cron. No PocketBase schema change, no new dependency. The hero stays on its random prayer for now.

## Verified

- `ruff` + `mypy` clean, `36 pytest` pass (7 new: cold-start, stability, duplicate-weighting, history-skip, auto-recycle, empty-corpus 404, assign writes).
- End-to-end against prod PocketBase + a local Redis: the one prod prayer that currently has a duplicate was picked **first**, `get_daily` stayed stable across calls, a second assign picked a different prayer, history grew, and the Mecca date key was correct.