### PR TITLE
feat(api): Discord bot — HTTP interactions + per-guild prayer scheduler

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -15,3 +15,8 @@ OPENAI_BASE_URL=https://api.groq.com/openai/v1
 AI_MODEL=openai/gpt-oss-120b
 
 REDIS_URL=redis://localhost:6379/0
+
+DISCORD_PUBLIC_KEY=
+DISCORD_APP_ID=
+DISCORD_BOT_TOKEN=
+DISCORD_GUILD_ID=

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.7"
+version = "0.1.8"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",
@@ -11,6 +11,8 @@ dependencies = [
     "slowapi==0.1.9",
     "arq==0.28.0",
     "redis==5.2.1",
+    "pynacl>=1.6.2",
+    "croniter>=6.2.2",
 ]
 
 [dependency-groups]
@@ -19,6 +21,7 @@ dev = [
     "mypy==1.14.1",
     "pytest==8.3.4",
     "pytest-asyncio==0.25.2",
+    "types-croniter>=6.2.2.20260518",
 ]
 
 [tool.ruff]

--- a/apps/api/scripts/apply_pb_schema.py
+++ b/apps/api/scripts/apply_pb_schema.py
@@ -17,8 +17,27 @@ _PRAYER_STATUS_VALUES = ["processing", "rejected", "duplicate", "failed"]
 _TAXONOMY_COLLECTIONS = ["categories", "types", "groups"]
 
 
-def _text_field(name: str) -> dict[str, Any]:
-    return {"name": name, "type": "text", "required": False, "hidden": False}
+def _text_field(name: str, *, required: bool = False) -> dict[str, Any]:
+    return {"name": name, "type": "text", "required": required, "hidden": False}
+
+
+def _bool_field(name: str) -> dict[str, Any]:
+    return {"name": name, "type": "bool", "required": False, "hidden": False}
+
+
+def _schedule_fields() -> list[dict[str, Any]]:
+    return [
+        _text_field("guild_id", required=True),
+        _text_field("channel_id", required=True),
+        _text_field("cron", required=True),
+        _text_field("timezone"),
+        _text_field("content_type", required=True),
+        _text_field("category"),
+        _text_field("label"),
+        _bool_field("enabled"),
+        _text_field("created_by"),
+        _text_field("last_run_at"),
+    ]
 
 
 async def _get_collection(
@@ -138,6 +157,46 @@ async def _migrate_taxonomy(
     print(f"migrated {collection}")
 
 
+async def _ensure_schedules(
+    http: httpx.AsyncClient, base: str, headers: dict[str, str]
+) -> None:
+    existing = await http.get(f"{base}/api/collections/schedules", headers=headers)
+    if existing.status_code == 200:
+        collection: dict[str, Any] = existing.json()
+        fields: list[dict[str, Any]] = collection["fields"]
+        names = _field_names(fields)
+        for field in _schedule_fields():
+            if field["name"] not in names:
+                fields.append(field)
+        indexes: list[str] = collection.get("indexes", [])
+        _ensure_index(indexes, "idx_schedules_enabled", "schedules", "enabled")
+        await _patch_collection(
+            http, base, headers, collection["id"], {"fields": fields, "indexes": indexes}
+        )
+        print("migrated schedules")
+        return
+
+    template = await _get_collection(http, base, headers, "prayers")
+    system_fields = [
+        field
+        for field in template["fields"]
+        if field.get("system") or field["type"] == "autodate"
+    ]
+    payload = {
+        "name": "schedules",
+        "type": "base",
+        "fields": system_fields + _schedule_fields(),
+        "indexes": [
+            "CREATE INDEX `idx_schedules_enabled` ON `schedules` (`enabled`)"
+        ],
+    }
+    created = await http.post(
+        f"{base}/api/collections", headers=headers, json=payload
+    )
+    created.raise_for_status()
+    print("created schedules")
+
+
 async def _authenticate(
     http: httpx.AsyncClient, base: str, email: str, password: str
 ) -> dict[str, str]:
@@ -159,6 +218,7 @@ async def main() -> None:
         await _migrate_prayers(http, base, headers)
         for collection in _TAXONOMY_COLLECTIONS:
             await _migrate_taxonomy(http, base, headers, collection)
+        await _ensure_schedules(http, base, headers)
 
 
 if __name__ == "__main__":

--- a/apps/api/scripts/register_discord_commands.py
+++ b/apps/api/scripts/register_discord_commands.py
@@ -1,0 +1,35 @@
+import asyncio
+import sys
+
+import httpx
+from src.features.discord.commands import command_definitions
+from src.features.discord.keys import DISCORD_API_BASE
+from src.shared.config.settings import get_settings
+
+
+async def main() -> None:
+    settings = get_settings()
+    if not settings.discord_bot_token or not settings.discord_app_id:
+        print("missing DISCORD_BOT_TOKEN or DISCORD_APP_ID")
+        return
+
+    guild = "" if "--global" in sys.argv else settings.discord_guild_id
+    if guild:
+        url = (
+            f"{DISCORD_API_BASE}/applications/{settings.discord_app_id}"
+            f"/guilds/{guild}/commands"
+        )
+        scope = f"guild {guild}"
+    else:
+        url = f"{DISCORD_API_BASE}/applications/{settings.discord_app_id}/commands"
+        scope = "global"
+
+    headers = {"Authorization": f"Bot {settings.discord_bot_token}"}
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        response = await http.put(url, headers=headers, json=command_definitions())
+        response.raise_for_status()
+        print(f"registered {len(response.json())} commands ({scope})")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/api/src/features/discord/commands.py
+++ b/apps/api/src/features/discord/commands.py
@@ -1,0 +1,162 @@
+from typing import Any
+
+from src.features.discord.keys import MANAGE_GUILD
+
+_STRING = 3
+_CHANNEL = 7
+_SUB_COMMAND = 1
+
+_TYPE_CHOICES = [
+    {"name": "qur'anic", "value": "quranic"},
+    {"name": "prophetic", "value": "prophetic"},
+    {"name": "athar", "value": "athar"},
+    {"name": "custom", "value": "custom"},
+]
+
+_CONTENT_CHOICES = [
+    {"name": "daily prayer", "value": "daily"},
+    {"name": "random prayer", "value": "random"},
+    {"name": "from a category", "value": "category"},
+]
+
+
+def command_definitions() -> list[dict[str, Any]]:
+    return [
+        {"name": "daily", "description": "Show today's prayer of the day"},
+        {
+            "name": "random",
+            "description": "Get a random du'a",
+            "options": [
+                {
+                    "name": "category",
+                    "description": "Filter by category",
+                    "type": _STRING,
+                    "required": False,
+                    "autocomplete": True,
+                },
+                {
+                    "name": "type",
+                    "description": "Filter by type",
+                    "type": _STRING,
+                    "required": False,
+                    "choices": _TYPE_CHOICES,
+                },
+            ],
+        },
+        {
+            "name": "search",
+            "description": "Search the du'as",
+            "options": [
+                {
+                    "name": "query",
+                    "description": "What to search for",
+                    "type": _STRING,
+                    "required": True,
+                },
+                {
+                    "name": "category",
+                    "description": "Filter by category",
+                    "type": _STRING,
+                    "required": False,
+                    "autocomplete": True,
+                },
+            ],
+        },
+        {"name": "categories", "description": "Browse the du'a categories"},
+        {
+            "name": "submit",
+            "description": "Submit a new du'a for review",
+            "options": [
+                {
+                    "name": "text",
+                    "description": "The du'a text",
+                    "type": _STRING,
+                    "required": True,
+                }
+            ],
+        },
+        {"name": "help", "description": "About the ad3oni bot"},
+        {
+            "name": "setup-daily",
+            "description": "Post the prayer of the day to a channel every day",
+            "default_member_permissions": str(MANAGE_GUILD),
+            "options": [
+                {
+                    "name": "channel",
+                    "description": "Channel to post in",
+                    "type": _CHANNEL,
+                    "required": True,
+                }
+            ],
+        },
+        {
+            "name": "schedule",
+            "description": "Schedule prayers in a channel",
+            "default_member_permissions": str(MANAGE_GUILD),
+            "options": [
+                {
+                    "name": "add",
+                    "description": "Add a schedule (cron or natural language)",
+                    "type": _SUB_COMMAND,
+                    "options": [
+                        {
+                            "name": "channel",
+                            "description": "Channel to post in",
+                            "type": _CHANNEL,
+                            "required": True,
+                        },
+                        {
+                            "name": "when",
+                            "description": "Natural language, e.g. every day at 3pm and 6pm",
+                            "type": _STRING,
+                            "required": False,
+                        },
+                        {
+                            "name": "cron",
+                            "description": "A cron expression, e.g. 0 15 * * *",
+                            "type": _STRING,
+                            "required": False,
+                        },
+                        {
+                            "name": "content",
+                            "description": "What to post (default: random)",
+                            "type": _STRING,
+                            "required": False,
+                            "choices": _CONTENT_CHOICES,
+                        },
+                        {
+                            "name": "category",
+                            "description": "Category when content is 'from a category'",
+                            "type": _STRING,
+                            "required": False,
+                            "autocomplete": True,
+                        },
+                        {
+                            "name": "timezone",
+                            "description": "IANA timezone (default: Asia/Riyadh)",
+                            "type": _STRING,
+                            "required": False,
+                        },
+                    ],
+                },
+                {
+                    "name": "list",
+                    "description": "List this server's schedules",
+                    "type": _SUB_COMMAND,
+                },
+                {
+                    "name": "remove",
+                    "description": "Remove a schedule by id",
+                    "type": _SUB_COMMAND,
+                    "options": [
+                        {
+                            "name": "id",
+                            "description": "The schedule id (from /schedule list)",
+                            "type": _STRING,
+                            "required": True,
+                        }
+                    ],
+                },
+            ],
+        },
+    ]

--- a/apps/api/src/features/discord/embeds.py
+++ b/apps/api/src/features/discord/embeds.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from src.features.prayers.schema import Prayer
+from src.features.taxonomy.schema import Category
+
+BRAND_COLOR = 0x6D5ACD
+SITE_URL = "https://ad3oni.com"
+
+
+def prayer_embed(prayer: Prayer) -> dict[str, Any]:
+    footer_parts = [
+        part
+        for part in (
+            prayer.source,
+            prayer.category.name if prayer.category else None,
+            prayer.type.name if prayer.type else None,
+        )
+        if part
+    ]
+    embed: dict[str, Any] = {
+        "description": prayer.text,
+        "color": BRAND_COLOR,
+        "url": SITE_URL,
+    }
+    if prayer.category:
+        embed["title"] = prayer.category.name
+    if footer_parts:
+        embed["footer"] = {"text": " · ".join(footer_parts)}
+    return embed
+
+
+def amin_components(count: int) -> list[dict[str, Any]]:
+    label = "آمين" if count <= 0 else f"آمين · {count}"
+    return [
+        {
+            "type": 1,
+            "components": [
+                {
+                    "type": 2,
+                    "style": 1,
+                    "label": label,
+                    "emoji": {"name": "🤲"},
+                    "custom_id": "amin",
+                }
+            ],
+        }
+    ]
+
+
+def help_embed() -> dict[str, Any]:
+    return {
+        "title": "أدعوني · ad3oni",
+        "description": (
+            "منصّة أدعية موثّقة. استخدم الأوامر التالية:\n\n"
+            "• `/daily` — دعاء اليوم\n"
+            "• `/random` — دعاء عشوائي (يمكن تحديد التصنيف)\n"
+            "• `/search` — البحث في الأدعية\n"
+            "• `/categories` — تصفّح التصنيفات\n"
+            "• `/submit` — إرسال دعاء جديد للمراجعة\n"
+            "• `/setup-daily` — نشر دعاء اليوم تلقائيًا في قناة\n"
+            "• `/schedule` — جدولة نشر الأدعية بوقت محدد أو بصيغة cron"
+        ),
+        "color": BRAND_COLOR,
+        "url": SITE_URL,
+    }
+
+
+def info_embed(message: str) -> dict[str, Any]:
+    return {"description": message, "color": BRAND_COLOR}
+
+
+def categories_embed(categories: list[Category]) -> dict[str, Any]:
+    groups: dict[str, list[str]] = {}
+    for category in categories:
+        group_name = category.group.name if category.group else "أخرى"
+        groups.setdefault(group_name, []).append(category.name)
+    sections = [
+        f"**{group_name}**\n{'، '.join(names)}"
+        for group_name, names in groups.items()
+    ]
+    return {
+        "title": "التصنيفات",
+        "description": "\n\n".join(sections),
+        "color": BRAND_COLOR,
+    }

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -1,0 +1,447 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, cast
+
+import httpx
+from arq import ArqRedis
+from croniter import croniter
+from openai import AsyncOpenAI
+
+from src.features.daily.service import DailyService
+from src.features.discord.embeds import (
+    amin_components,
+    categories_embed,
+    help_embed,
+    info_embed,
+    prayer_embed,
+)
+from src.features.discord.keys import (
+    APPLICATION_COMMAND,
+    APPLICATION_COMMAND_AUTOCOMPLETE,
+    APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
+    CHANNEL_MESSAGE_WITH_SOURCE,
+    DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+    EPHEMERAL_FLAG,
+    MANAGE_GUILD,
+    MESSAGE_COMPONENT,
+    PONG,
+    UPDATE_MESSAGE,
+    amin_count_key,
+    submit_cooldown_key,
+)
+from src.features.discord.parse import DEFAULT_TIMEZONE, parse_schedule
+from src.features.discord.rest import DiscordRest
+from src.features.discord.schema import Schedule
+from src.features.discord.service import DiscordScheduleService
+from src.features.prayers.schema import PrayerSubmission
+from src.features.prayers.service import PrayerService
+from src.features.taxonomy.service import TaxonomyService
+from src.shared.config.settings import Settings
+from src.shared.errors.exceptions import NotFoundError, ValidationError
+from src.shared.pocketbase.client import PocketBaseClient
+
+_DAILY_CRON = "1 0 * * *"
+_SUBMIT_COOLDOWN_SECONDS = 30
+_SEARCH_LIMIT = 3
+
+
+@dataclass(slots=True)
+class DiscordDeps:
+    settings: Settings
+    pocketbase: PocketBaseClient
+    queue: ArqRedis
+    ai: AsyncOpenAI
+    http: httpx.AsyncClient
+
+
+@dataclass(slots=True)
+class InteractionResult:
+    response: dict[str, Any]
+    background: Callable[[], Awaitable[None]] | None = None
+
+
+def _message(
+    embeds: list[dict[str, Any]],
+    components: list[dict[str, Any]] | None = None,
+    *,
+    ephemeral: bool = False,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {"embeds": embeds}
+    if components is not None:
+        data["components"] = components
+    if ephemeral:
+        data["flags"] = EPHEMERAL_FLAG
+    return {"type": CHANNEL_MESSAGE_WITH_SOURCE, "data": data}
+
+
+def _ephemeral(message: str) -> dict[str, Any]:
+    return _message([info_embed(message)], ephemeral=True)
+
+
+def _options(options: list[dict[str, Any]]) -> dict[str, Any]:
+    return {option["name"]: option.get("value") for option in options}
+
+
+def _user_id(payload: dict[str, Any]) -> str:
+    member = payload.get("member") or {}
+    user = member.get("user") or payload.get("user") or {}
+    return str(user.get("id", ""))
+
+
+def _has_manage_guild(payload: dict[str, Any]) -> bool:
+    member = payload.get("member")
+    if not member:
+        return False
+    try:
+        permissions = int(member.get("permissions", "0"))
+    except (TypeError, ValueError):
+        return False
+    return bool(permissions & MANAGE_GUILD)
+
+
+def _focused_option(data: dict[str, Any]) -> dict[str, Any] | None:
+    def walk(options: list[dict[str, Any]]) -> dict[str, Any] | None:
+        for option in options:
+            if option.get("focused"):
+                return option
+            nested = option.get("options")
+            if nested and (found := walk(nested)):
+                return found
+        return None
+
+    return walk(data.get("options", []))
+
+
+def _schedule_summary(schedule: Schedule) -> str:
+    target = (
+        f"category: {schedule.category}"
+        if schedule.content_type == "category" and schedule.category
+        else schedule.content_type
+    )
+    return (
+        f"• `{schedule.id}` — `{schedule.cron}` ({schedule.timezone}) → "
+        f"{target} in <#{schedule.channel_id}>"
+    )
+
+
+def _confirm_created(schedules: list[Schedule]) -> str:
+    lines = "\n".join(_schedule_summary(schedule) for schedule in schedules)
+    return f"تمت إضافة الجدولة:\n{lines}"
+
+
+async def handle_interaction(
+    payload: dict[str, Any], deps: DiscordDeps
+) -> InteractionResult:
+    interaction_type = payload.get("type")
+    if interaction_type == APPLICATION_COMMAND:
+        return await _handle_command(payload, deps)
+    if interaction_type == MESSAGE_COMPONENT:
+        return await _handle_component(payload, deps)
+    if interaction_type == APPLICATION_COMMAND_AUTOCOMPLETE:
+        return await _handle_autocomplete(payload, deps)
+    return InteractionResult({"type": PONG})
+
+
+async def _handle_command(
+    payload: dict[str, Any], deps: DiscordDeps
+) -> InteractionResult:
+    data = payload["data"]
+    name = data["name"]
+    options = _options(data.get("options", []))
+
+    if name == "daily":
+        return await _handle_daily(deps)
+    if name == "random":
+        return await _handle_random(deps, options)
+    if name == "search":
+        return await _handle_search(deps, options)
+    if name == "categories":
+        return await _handle_categories(deps)
+    if name == "submit":
+        return await _handle_submit(payload, deps, options)
+    if name == "help":
+        return InteractionResult(_message([help_embed()], ephemeral=True))
+    if name == "setup-daily":
+        return await _handle_setup_daily(payload, deps, options)
+    if name == "schedule":
+        return await _handle_schedule(payload, deps, data)
+    return InteractionResult(_ephemeral("أمر غير معروف."))
+
+
+async def _handle_daily(deps: DiscordDeps) -> InteractionResult:
+    service = DailyService(deps.pocketbase, deps.queue)
+    try:
+        prayer = await service.get_daily()
+    except NotFoundError:
+        return InteractionResult(_ephemeral("لا توجد أدعية متاحة بعد."))
+    return InteractionResult(
+        _message([prayer_embed(prayer)], amin_components(0))
+    )
+
+
+async def _handle_random(
+    deps: DiscordDeps, options: dict[str, Any]
+) -> InteractionResult:
+    service = PrayerService(deps.pocketbase, deps.queue)
+    try:
+        prayer = await service.random_prayer(
+            category=options.get("category"), type_=options.get("type")
+        )
+    except NotFoundError:
+        return InteractionResult(_ephemeral("لا توجد أدعية مطابقة."))
+    return InteractionResult(
+        _message([prayer_embed(prayer)], amin_components(0))
+    )
+
+
+async def _handle_search(
+    deps: DiscordDeps, options: dict[str, Any]
+) -> InteractionResult:
+    service = PrayerService(deps.pocketbase, deps.queue)
+    page = await service.list_prayers(
+        q=options.get("query"),
+        category=options.get("category"),
+        per_page=_SEARCH_LIMIT,
+    )
+    if not page.items:
+        return InteractionResult(_ephemeral("لا توجد نتائج."))
+    embeds = [prayer_embed(prayer) for prayer in page.items]
+    return InteractionResult(_message(embeds))
+
+
+async def _handle_categories(deps: DiscordDeps) -> InteractionResult:
+    service = TaxonomyService(deps.pocketbase)
+    categories = await service.list_categories()
+    return InteractionResult(_message([categories_embed(categories)], ephemeral=True))
+
+
+async def _handle_submit(
+    payload: dict[str, Any], deps: DiscordDeps, options: dict[str, Any]
+) -> InteractionResult:
+    text = str(options.get("text", "")).strip()
+    if len(text) < 3:
+        return InteractionResult(_ephemeral("الدعاء قصير جدًا."))
+
+    user_id = _user_id(payload)
+    cooldown_key = submit_cooldown_key(user_id)
+    if await deps.queue.get(cooldown_key) is not None:
+        return InteractionResult(_ephemeral("انتظر قليلًا قبل إرسال دعاء آخر."))
+
+    service = PrayerService(deps.pocketbase, deps.queue)
+    try:
+        await service.submit_prayer(PrayerSubmission(text=text))
+    except ValidationError as error:
+        return InteractionResult(_ephemeral(error.message))
+
+    await deps.queue.set(cooldown_key, "1", ex=_SUBMIT_COOLDOWN_SECONDS)
+    return InteractionResult(
+        _ephemeral("تم استلام دعائك، وسيُراجَع ويُضاف قريبًا إن شاء الله.")
+    )
+
+
+async def _handle_setup_daily(
+    payload: dict[str, Any], deps: DiscordDeps, options: dict[str, Any]
+) -> InteractionResult:
+    if not _has_manage_guild(payload):
+        return InteractionResult(_ephemeral("تحتاج صلاحية إدارة الخادم."))
+    guild_id = str(payload.get("guild_id", ""))
+    channel_id = str(options.get("channel", ""))
+    service = DiscordScheduleService(
+        deps.pocketbase, deps.settings.discord_schedule_limit
+    )
+    try:
+        created = await service.create(
+            guild_id=guild_id,
+            channel_id=channel_id,
+            cron=_DAILY_CRON,
+            timezone=DEFAULT_TIMEZONE,
+            content_type="daily",
+            category=None,
+            label="daily prayer",
+            created_by=_user_id(payload),
+        )
+    except ValidationError as error:
+        return InteractionResult(_ephemeral(error.message))
+    return InteractionResult(
+        _ephemeral(
+            f"سيُنشر دعاء اليوم في <#{channel_id}> يوميًا الساعة 12:01 منتصف الليل (توقيت مكة).\n"
+            f"`{created.id}`"
+        )
+    )
+
+
+async def _handle_schedule(
+    payload: dict[str, Any], deps: DiscordDeps, data: dict[str, Any]
+) -> InteractionResult:
+    if not _has_manage_guild(payload):
+        return InteractionResult(_ephemeral("تحتاج صلاحية إدارة الخادم."))
+    sub = data["options"][0]
+    sub_name = sub["name"]
+    options = _options(sub.get("options", []))
+    if sub_name == "add":
+        return await _handle_schedule_add(payload, deps, options)
+    if sub_name == "list":
+        return await _handle_schedule_list(payload, deps)
+    if sub_name == "remove":
+        return await _handle_schedule_remove(payload, deps, options)
+    return InteractionResult(_ephemeral("أمر غير معروف."))
+
+
+async def _handle_schedule_add(
+    payload: dict[str, Any], deps: DiscordDeps, options: dict[str, Any]
+) -> InteractionResult:
+    guild_id = str(payload.get("guild_id", ""))
+    channel_id = str(options.get("channel", ""))
+    content_type = str(options.get("content") or "random")
+    category = options.get("category")
+    timezone = str(options.get("timezone") or DEFAULT_TIMEZONE)
+    cron = options.get("cron")
+    when = options.get("when")
+    created_by = _user_id(payload)
+    service = DiscordScheduleService(
+        deps.pocketbase, deps.settings.discord_schedule_limit
+    )
+
+    if content_type == "category" and not category:
+        return InteractionResult(_ephemeral("اختر تصنيفًا عند اختيار 'from a category'."))
+
+    if cron:
+        if not croniter.is_valid(str(cron)):
+            return InteractionResult(_ephemeral(f"تعبير cron غير صحيح: `{cron}`"))
+        try:
+            created = await service.create(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                cron=str(cron),
+                timezone=timezone,
+                content_type=content_type,
+                category=category,
+                label=None,
+                created_by=created_by,
+            )
+        except ValidationError as error:
+            return InteractionResult(_ephemeral(error.message))
+        return InteractionResult(_ephemeral(_confirm_created([created])))
+
+    if when:
+        return InteractionResult(
+            {
+                "type": DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+                "data": {"flags": EPHEMERAL_FLAG},
+            },
+            background=_schedule_add_background(
+                payload, deps, service, str(when), guild_id, channel_id, created_by
+            ),
+        )
+
+    return InteractionResult(_ephemeral("زوّدني بتعبير cron أو وصف الوقت (when)."))
+
+
+def _schedule_add_background(
+    payload: dict[str, Any],
+    deps: DiscordDeps,
+    service: DiscordScheduleService,
+    when: str,
+    guild_id: str,
+    channel_id: str,
+    created_by: str,
+) -> Callable[[], Awaitable[None]]:
+    async def run() -> None:
+        rest = DiscordRest(deps.http, deps.settings.discord_bot_token)
+        app_id = deps.settings.discord_app_id
+        token = payload["token"]
+        parsed = await parse_schedule(deps.ai, deps.settings.ai_model, when)
+        if parsed is None:
+            await rest.edit_original(
+                app_id,
+                token,
+                info_embed("لم أفهم الوقت المطلوب. جرّب: every day at 3pm and 6pm"),
+            )
+            return
+        created: list[Schedule] = []
+        try:
+            for expr in parsed.crons:
+                created.append(
+                    await service.create(
+                        guild_id=guild_id,
+                        channel_id=channel_id,
+                        cron=expr,
+                        timezone=parsed.timezone,
+                        content_type=parsed.content_type,
+                        category=parsed.category,
+                        label=parsed.label,
+                        created_by=created_by,
+                    )
+                )
+        except ValidationError as error:
+            await rest.edit_original(app_id, token, info_embed(error.message))
+            return
+        await rest.edit_original(app_id, token, info_embed(_confirm_created(created)))
+
+    return run
+
+
+async def _handle_schedule_list(
+    payload: dict[str, Any], deps: DiscordDeps
+) -> InteractionResult:
+    guild_id = str(payload.get("guild_id", ""))
+    service = DiscordScheduleService(deps.pocketbase)
+    schedules = await service.list_for_guild(guild_id)
+    if not schedules:
+        return InteractionResult(_ephemeral("لا توجد جدولات في هذا الخادم."))
+    body = "\n".join(_schedule_summary(schedule) for schedule in schedules)
+    return InteractionResult(_message([info_embed(body)], ephemeral=True))
+
+
+async def _handle_schedule_remove(
+    payload: dict[str, Any], deps: DiscordDeps, options: dict[str, Any]
+) -> InteractionResult:
+    guild_id = str(payload.get("guild_id", ""))
+    schedule_id = str(options.get("id", ""))
+    service = DiscordScheduleService(deps.pocketbase)
+    removed = await service.remove(guild_id, schedule_id)
+    if not removed:
+        return InteractionResult(_ephemeral("لم أجد جدولة بهذا المعرّف."))
+    return InteractionResult(_ephemeral("تم حذف الجدولة."))
+
+
+async def _handle_component(
+    payload: dict[str, Any], deps: DiscordDeps
+) -> InteractionResult:
+    custom_id = payload["data"].get("custom_id")
+    message = payload.get("message", {})
+    embeds = message.get("embeds", [])
+    if custom_id != "amin":
+        return InteractionResult({"type": UPDATE_MESSAGE, "data": {"embeds": embeds}})
+    count = await cast(
+        "Awaitable[int]", deps.queue.incr(amin_count_key(message.get("id", "")))
+    )
+    return InteractionResult(
+        {
+            "type": UPDATE_MESSAGE,
+            "data": {"embeds": embeds, "components": amin_components(count)},
+        }
+    )
+
+
+async def _handle_autocomplete(
+    payload: dict[str, Any], deps: DiscordDeps
+) -> InteractionResult:
+    focused = _focused_option(payload["data"]) or {}
+    typed = str(focused.get("value") or "").strip()
+    service = TaxonomyService(deps.pocketbase)
+    categories = await service.list_categories()
+    matches = [
+        category
+        for category in categories
+        if not typed
+        or typed in category.name
+        or typed.lower() in category.slug.lower()
+    ][:25]
+    choices = [{"name": category.name, "value": category.slug} for category in matches]
+    return InteractionResult(
+        {
+            "type": APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
+            "data": {"choices": choices},
+        }
+    )

--- a/apps/api/src/features/discord/keys.py
+++ b/apps/api/src/features/discord/keys.py
@@ -1,0 +1,26 @@
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+MANAGE_GUILD = 0x20
+
+PING = 1
+APPLICATION_COMMAND = 2
+MESSAGE_COMPONENT = 3
+APPLICATION_COMMAND_AUTOCOMPLETE = 4
+
+PONG = 1
+CHANNEL_MESSAGE_WITH_SOURCE = 4
+DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
+UPDATE_MESSAGE = 7
+APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8
+
+EPHEMERAL_FLAG = 1 << 6
+
+AMIN_BUTTON_PREFIX = "amin"
+
+
+def amin_count_key(message_id: str) -> str:
+    return f"ad3oni:discord:amin:{message_id}"
+
+
+def submit_cooldown_key(user_id: str) -> str:
+    return f"ad3oni:discord:cooldown:{user_id}"

--- a/apps/api/src/features/discord/parse.py
+++ b/apps/api/src/features/discord/parse.py
@@ -1,0 +1,76 @@
+from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import croniter
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+from src.shared.ai.structured import complete_json
+from src.shared.errors.exceptions import UpstreamError
+
+DEFAULT_TIMEZONE = "Asia/Riyadh"
+
+ContentType = Literal["daily", "random", "category"]
+
+_PARSE_SYSTEM = (
+    "You convert a natural-language recurring schedule into standard 5-field cron "
+    "expressions (minute hour day-of-month month day-of-week). Rules:\n"
+    "- Return one cron expression per distinct firing time.\n"
+    "- 'every day at 3pm and 6pm' -> [\"0 15 * * *\", \"0 18 * * *\"].\n"
+    "- Interpret times in the provided default timezone unless the text names another; "
+    "set 'timezone' to a valid IANA name.\n"
+    "- content_type is 'daily' (the prayer of the day), 'random', or 'category'. "
+    "Default to 'random'. Only set 'category' when content_type is 'category'.\n"
+    "- 'label' is a short human description of the schedule.\n"
+    "- If the text is not a schedule, return an empty crons list."
+)
+
+
+def _parse_user(text: str, default_timezone: str) -> str:
+    return f"Default timezone: {default_timezone}\nSchedule: {text}"
+
+
+class NLSchedule(BaseModel):
+    crons: list[str]
+    timezone: str
+    content_type: ContentType
+    category: str | None
+    label: str
+
+
+def _valid_timezone(name: str) -> bool:
+    try:
+        ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return False
+    return True
+
+
+async def parse_schedule(
+    ai: AsyncOpenAI,
+    model: str,
+    text: str,
+    default_timezone: str = DEFAULT_TIMEZONE,
+) -> NLSchedule | None:
+    try:
+        result = await complete_json(
+            ai,
+            model,
+            _PARSE_SYSTEM,
+            _parse_user(text, default_timezone),
+            NLSchedule,
+            reasoning_effort="low",
+        )
+    except UpstreamError:
+        return None
+
+    valid_crons = [expr for expr in result.crons if croniter.is_valid(expr)]
+    if not valid_crons:
+        return None
+
+    result.crons = valid_crons
+    if not _valid_timezone(result.timezone):
+        result.timezone = default_timezone
+    if result.content_type != "category":
+        result.category = None
+    return result

--- a/apps/api/src/features/discord/rest.py
+++ b/apps/api/src/features/discord/rest.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+import httpx
+
+from src.features.discord.keys import DISCORD_API_BASE
+
+
+class DiscordRest:
+    def __init__(self, http: httpx.AsyncClient, bot_token: str) -> None:
+        self._http = http
+        self._token = bot_token
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bot {self._token}"}
+
+    async def post_message(
+        self,
+        channel_id: str,
+        embed: dict[str, Any],
+        components: list[dict[str, Any]] | None = None,
+    ) -> httpx.Response:
+        payload: dict[str, Any] = {"embeds": [embed]}
+        if components is not None:
+            payload["components"] = components
+        return await self._http.post(
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+            headers=self._headers,
+            json=payload,
+        )
+
+    async def edit_original(
+        self,
+        app_id: str,
+        interaction_token: str,
+        embed: dict[str, Any],
+        components: list[dict[str, Any]] | None = None,
+    ) -> httpx.Response:
+        payload: dict[str, Any] = {"embeds": [embed]}
+        if components is not None:
+            payload["components"] = components
+        return await self._http.patch(
+            f"{DISCORD_API_BASE}/webhooks/{app_id}/{interaction_token}/messages/@original",
+            json=payload,
+        )

--- a/apps/api/src/features/discord/router.py
+++ b/apps/api/src/features/discord/router.py
@@ -1,0 +1,39 @@
+import json
+
+from fastapi import APIRouter, BackgroundTasks, Request, Response
+from fastapi.responses import JSONResponse
+
+from src.features.discord.handlers import DiscordDeps, handle_interaction
+from src.features.discord.keys import PING, PONG
+from src.features.discord.verify import verify_signature
+
+router = APIRouter(prefix="/discord", tags=["discord"])
+
+
+@router.post("/interactions")
+async def interactions(request: Request, background_tasks: BackgroundTasks) -> Response:
+    body = await request.body()
+    signature = request.headers.get("X-Signature-Ed25519", "")
+    timestamp = request.headers.get("X-Signature-Timestamp", "")
+
+    state = request.app.state.app_state
+    if not verify_signature(
+        state.settings.discord_public_key, signature, timestamp, body
+    ):
+        return Response(status_code=401)
+
+    payload = json.loads(body)
+    if payload.get("type") == PING:
+        return JSONResponse({"type": PONG})
+
+    deps = DiscordDeps(
+        settings=state.settings,
+        pocketbase=state.pocketbase,
+        queue=state.queue,
+        ai=state.ai,
+        http=state.http,
+    )
+    result = await handle_interaction(payload, deps)
+    if result.background is not None:
+        background_tasks.add_task(result.background)
+    return JSONResponse(result.response)

--- a/apps/api/src/features/discord/scheduler.py
+++ b/apps/api/src/features/discord/scheduler.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from arq import ArqRedis
+from croniter import croniter
+
+from src.features.daily.service import DailyService
+from src.features.discord.embeds import amin_components, prayer_embed
+from src.features.discord.rest import DiscordRest
+from src.features.discord.schema import Schedule
+from src.features.discord.service import DiscordScheduleService
+from src.features.prayers.schema import Prayer
+from src.features.prayers.service import PrayerService
+from src.shared.errors.exceptions import NotFoundError
+from src.shared.logging.setup import get_logger
+from src.shared.queue.context import WorkerContext
+
+logger = get_logger("api.discord.scheduler")
+
+
+def _minute_now(timezone: str) -> datetime | None:
+    try:
+        zone = ZoneInfo(timezone)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    return datetime.now(zone).replace(second=0, microsecond=0)
+
+
+def _is_due(schedule: Schedule, now: datetime) -> bool:
+    if not croniter.is_valid(schedule.cron):
+        return False
+    if not croniter.match(schedule.cron, now):
+        return False
+    return schedule.last_run_at != now.isoformat()
+
+
+async def _resolve_prayer(
+    schedule: Schedule, daily: DailyService, prayers: PrayerService
+) -> Prayer | None:
+    try:
+        if schedule.content_type == "daily":
+            return await daily.get_daily()
+        if schedule.content_type == "category" and schedule.category:
+            return await prayers.random_prayer(category=schedule.category)
+        return await prayers.random_prayer()
+    except NotFoundError:
+        return None
+
+
+async def run_due_schedules(context: WorkerContext, redis: ArqRedis) -> None:
+    if not context.settings.discord_bot_token:
+        return
+
+    service = DiscordScheduleService(context.pocketbase)
+    schedules = await service.list_enabled()
+    if not schedules:
+        return
+
+    daily = DailyService(context.pocketbase, redis)
+    prayers = PrayerService(context.pocketbase, redis)
+    rest = DiscordRest(context.http, context.settings.discord_bot_token)
+
+    for schedule in schedules:
+        now = _minute_now(schedule.timezone)
+        if now is None or not _is_due(schedule, now):
+            continue
+
+        prayer = await _resolve_prayer(schedule, daily, prayers)
+        if prayer is None:
+            continue
+
+        response = await rest.post_message(
+            schedule.channel_id, prayer_embed(prayer), amin_components(0)
+        )
+        if response.status_code in (403, 404):
+            await service.disable(schedule.id)
+            logger.warning(
+                "discord_schedule_disabled id=%s status=%s",
+                schedule.id,
+                response.status_code,
+            )
+            continue
+        if response.status_code >= 400:
+            logger.warning(
+                "discord_schedule_post_failed id=%s status=%s",
+                schedule.id,
+                response.status_code,
+            )
+            continue
+
+        await service.mark_run(schedule.id, now.isoformat())

--- a/apps/api/src/features/discord/schema.py
+++ b/apps/api/src/features/discord/schema.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Schedule(BaseModel):
+    id: str
+    guild_id: str
+    channel_id: str
+    cron: str
+    timezone: str
+    content_type: str
+    category: str | None = None
+    label: str | None = None
+    enabled: bool = True
+    last_run_at: str | None = None
+
+
+def to_schedule(record: dict[str, Any]) -> Schedule:
+    return Schedule(
+        id=record["id"],
+        guild_id=record.get("guild_id", ""),
+        channel_id=record.get("channel_id", ""),
+        cron=record.get("cron", ""),
+        timezone=record.get("timezone") or "Asia/Riyadh",
+        content_type=record.get("content_type", "random"),
+        category=record.get("category") or None,
+        label=record.get("label") or None,
+        enabled=bool(record.get("enabled", False)),
+        last_run_at=record.get("last_run_at") or None,
+    )

--- a/apps/api/src/features/discord/service.py
+++ b/apps/api/src/features/discord/service.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+from src.features.discord.schema import Schedule, to_schedule
+from src.shared.errors.exceptions import ValidationError
+from src.shared.pocketbase.client import PocketBaseClient
+from src.shared.pocketbase.filters import combine, quote
+
+_COLLECTION = "schedules"
+_PAGE_SIZE = 200
+
+
+class DiscordScheduleService:
+    def __init__(self, pocketbase: PocketBaseClient, limit: int = 15) -> None:
+        self._pocketbase = pocketbase
+        self._limit = limit
+
+    async def list_for_guild(self, guild_id: str) -> list[Schedule]:
+        data = await self._pocketbase.list_records(
+            _COLLECTION,
+            {
+                "filter": f"guild_id = {quote(guild_id)}",
+                "sort": "created",
+                "perPage": _PAGE_SIZE,
+            },
+        )
+        return [to_schedule(record) for record in data.get("items", [])]
+
+    async def list_enabled(self) -> list[Schedule]:
+        schedules: list[Schedule] = []
+        page = 1
+        while True:
+            data = await self._pocketbase.list_records(
+                _COLLECTION,
+                {"filter": "enabled = true", "page": page, "perPage": _PAGE_SIZE},
+            )
+            items = data.get("items", [])
+            schedules.extend(to_schedule(record) for record in items)
+            if len(items) < _PAGE_SIZE:
+                return schedules
+            page += 1
+
+    async def create(
+        self,
+        *,
+        guild_id: str,
+        channel_id: str,
+        cron: str,
+        timezone: str,
+        content_type: str,
+        category: str | None,
+        label: str | None,
+        created_by: str,
+    ) -> Schedule:
+        existing = await self.list_for_guild(guild_id)
+        if len(existing) >= self._limit:
+            raise ValidationError(
+                f"This server already has the maximum of {self._limit} schedules."
+            )
+        payload: dict[str, Any] = {
+            "guild_id": guild_id,
+            "channel_id": channel_id,
+            "cron": cron,
+            "timezone": timezone,
+            "content_type": content_type,
+            "category": category or "",
+            "label": label or "",
+            "enabled": True,
+            "created_by": created_by,
+        }
+        record = await self._pocketbase.create_record(_COLLECTION, payload)
+        return to_schedule(record)
+
+    async def remove(self, guild_id: str, schedule_id: str) -> bool:
+        record = await self._pocketbase.get_first(
+            _COLLECTION,
+            combine(f"id = {quote(schedule_id)}", f"guild_id = {quote(guild_id)}"),
+        )
+        if record is None:
+            return False
+        await self._pocketbase.delete_record(_COLLECTION, schedule_id)
+        return True
+
+    async def mark_run(self, schedule_id: str, stamp: str) -> None:
+        await self._pocketbase.update_record(
+            _COLLECTION, schedule_id, {"last_run_at": stamp}
+        )
+
+    async def disable(self, schedule_id: str) -> None:
+        await self._pocketbase.update_record(
+            _COLLECTION, schedule_id, {"enabled": False}
+        )

--- a/apps/api/src/features/discord/verify.py
+++ b/apps/api/src/features/discord/verify.py
@@ -1,0 +1,15 @@
+from nacl.exceptions import BadSignatureError
+from nacl.signing import VerifyKey
+
+
+def verify_signature(
+    public_key: str, signature: str, timestamp: str, body: bytes
+) -> bool:
+    if not public_key:
+        return False
+    try:
+        verify_key = VerifyKey(bytes.fromhex(public_key))
+        verify_key.verify(timestamp.encode() + body, bytes.fromhex(signature))
+    except (BadSignatureError, ValueError):
+        return False
+    return True

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from src.features.daily.router import router as daily_router
+from src.features.discord.router import router as discord_router
 from src.features.health.router import router as health_router
 from src.features.prayers.router import router as prayers_router
 from src.features.taxonomy.router import router as taxonomy_router
@@ -28,6 +29,7 @@ def create_app() -> FastAPI:
     app.include_router(taxonomy_router, prefix=API_PREFIX)
     app.include_router(prayers_router, prefix=API_PREFIX)
     app.include_router(daily_router, prefix=API_PREFIX)
+    app.include_router(discord_router, prefix=API_PREFIX)
 
     return app
 

--- a/apps/api/src/shared/config/settings.py
+++ b/apps/api/src/shared/config/settings.py
@@ -53,6 +53,12 @@ class Settings(BaseSettings):
 
     submit_rate_limit: str = "5/minute"
 
+    discord_public_key: str = ""
+    discord_app_id: str = ""
+    discord_bot_token: str = ""
+    discord_guild_id: str = ""
+    discord_schedule_limit: int = 15
+
     @property
     def is_production(self) -> bool:
         return self.environment == "prod"

--- a/apps/api/src/shared/lifespan/lifespan.py
+++ b/apps/api/src/shared/lifespan/lifespan.py
@@ -30,7 +30,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         queue = await create_arq_pool(settings)
 
         app.state.app_state = AppState(
-            settings=settings, pocketbase=pocketbase, ai=ai, queue=queue
+            settings=settings,
+            pocketbase=pocketbase,
+            ai=ai,
+            queue=queue,
+            http=http,
         )
         logger.info("startup_complete environment=%s", settings.environment)
 

--- a/apps/api/src/shared/lifespan/state.py
+++ b/apps/api/src/shared/lifespan/state.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import httpx
 from arq import ArqRedis
 from openai import AsyncOpenAI
 
@@ -13,3 +14,4 @@ class AppState:
     pocketbase: PocketBaseClient
     ai: AsyncOpenAI
     queue: ArqRedis
+    http: httpx.AsyncClient

--- a/apps/api/src/shared/pocketbase/client.py
+++ b/apps/api/src/shared/pocketbase/client.py
@@ -75,6 +75,17 @@ class PocketBaseClient:
         )
         return data or {}
 
+    async def delete_record(self, collection: str, record_id: str) -> None:
+        path = f"/api/collections/{collection}/records/{record_id}"
+        response = await self._send("DELETE", path)
+        if response.status_code == 401 and self.has_credentials:
+            await self.authenticate()
+            response = await self._send("DELETE", path)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise UpstreamError(f"PocketBase request failed: {exc}") from exc
+
     async def _request(
         self,
         method: str,

--- a/apps/api/src/shared/queue/settings.py
+++ b/apps/api/src/shared/queue/settings.py
@@ -6,6 +6,7 @@ from arq import ArqRedis, cron
 
 from src.features.daily.keys import MECCA_TIMEZONE
 from src.features.daily.selection import assign_daily_prayer
+from src.features.discord.scheduler import run_due_schedules
 from src.features.ingestion.finalize import finalize_failed
 from src.features.ingestion.pipeline import run_pipeline
 from src.shared.ai.client import create_ai_client
@@ -68,9 +69,21 @@ async def assign_daily(ctx: dict[Any, Any]) -> None:
         logger.exception("daily_prayer_assignment_failed")
 
 
+async def dispatch_schedules(ctx: dict[Any, Any]) -> None:
+    context = get_worker_context(ctx)
+    redis: ArqRedis = ctx["redis"]
+    try:
+        await run_due_schedules(context, redis)
+    except Exception:
+        logger.exception("discord_schedule_dispatch_failed")
+
+
 class WorkerSettings:
     functions = [process_prayer]
-    cron_jobs = [cron(assign_daily, hour=0, minute=0, run_at_startup=False)]
+    cron_jobs = [
+        cron(assign_daily, hour=0, minute=0, run_at_startup=False),
+        cron(dispatch_schedules, minute=set(range(60)), second=0),
+    ]
     timezone = ZoneInfo(MECCA_TIMEZONE)
     on_startup = startup
     on_shutdown = shutdown

--- a/apps/api/tests/test_discord.py
+++ b/apps/api/tests/test_discord.py
@@ -1,0 +1,382 @@
+import json
+from datetime import datetime
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from nacl.signing import SigningKey
+from openai import AsyncOpenAI
+from src.features.discord import parse as parse_module
+from src.features.discord.parse import NLSchedule, parse_schedule
+from src.features.discord.scheduler import _is_due, run_due_schedules
+from src.features.discord.schema import Schedule
+from src.features.discord.verify import verify_signature
+from src.main import create_app
+from src.shared.config.settings import Settings
+from src.shared.lifespan.state import AppState
+from src.shared.pocketbase.client import PocketBaseClient
+from src.shared.queue.context import WorkerContext
+
+GROUP: dict[str, Any] = {"id": "g1", "name": "المشاعر", "slug": "emotion"}
+CATEGORY: dict[str, Any] = {
+    "id": "c1",
+    "name": "القلق والهمّ",
+    "slug": "anxiety",
+    "expand": {"group": GROUP},
+}
+PRAYER_TYPE: dict[str, Any] = {"id": "t1", "name": "نبوي", "slug": "prophetic"}
+PRAYER: dict[str, Any] = {
+    "id": "p1",
+    "text": "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي",
+    "status": "confirmed",
+    "source": "صحيح مسلم",
+    "created": "2026-05-30 00:00:00.000Z",
+    "updated": "2026-05-30 00:00:00.000Z",
+    "expand": {"category": CATEGORY, "type": PRAYER_TYPE},
+}
+
+
+class FakePocketBase:
+    def __init__(self) -> None:
+        self.schedules: list[dict[str, Any]] = []
+        self.created: list[dict[str, Any]] = []
+        self.updated: list[tuple[str, dict[str, Any]]] = []
+        self.deleted: list[str] = []
+        self._counter = 0
+
+    async def list_records(
+        self, collection: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        if collection == "categories":
+            items = [CATEGORY]
+        elif collection == "prayers":
+            items = [PRAYER]
+        elif collection == "schedules":
+            items = self.schedules
+        else:
+            items = []
+        return {
+            "items": items,
+            "page": 1,
+            "perPage": 20,
+            "totalItems": len(items),
+            "totalPages": 1,
+        }
+
+    async def get_first(
+        self, collection: str, filter_: str, *, expand: str | None = None
+    ) -> dict[str, Any] | None:
+        if collection == "prayers":
+            return PRAYER
+        if collection == "schedules":
+            return self.schedules[0] if self.schedules else None
+        if collection in {"categories", "types", "groups"}:
+            return CATEGORY
+        return None
+
+    async def create_record(
+        self, collection: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self._counter += 1
+        record = {
+            **payload,
+            "id": f"rec{self._counter}",
+            "created": "2026-05-30 00:00:00.000Z",
+            "updated": "2026-05-30 00:00:00.000Z",
+        }
+        if collection == "schedules":
+            self.schedules.append(record)
+        self.created.append(record)
+        return record
+
+    async def update_record(
+        self, collection: str, record_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.updated.append((record_id, payload))
+        return {"id": record_id, **payload}
+
+    async def delete_record(self, collection: str, record_id: str) -> None:
+        self.deleted.append(record_id)
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.counters: dict[str, int] = {}
+
+    async def get(self, key: str) -> bytes | None:
+        value = self.values.get(key)
+        return value.encode() if value is not None else None
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.values[key] = value
+
+    async def incr(self, key: str) -> int:
+        self.counters[key] = self.counters.get(key, 0) + 1
+        return self.counters[key]
+
+
+class FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class FakeHttp:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.posts: list[str] = []
+
+    async def post(
+        self, url: str, headers: dict[str, str], json: dict[str, Any]
+    ) -> FakeResponse:
+        self.posts.append(url)
+        return FakeResponse(self.status_code)
+
+
+def _settings(public_key: str) -> Settings:
+    return Settings(
+        discord_public_key=public_key,
+        discord_app_id="app1",
+        discord_bot_token="bot-token",
+    )
+
+
+def _client(public_key: str, pocketbase: FakePocketBase, redis: FakeRedis) -> TestClient:
+    app = create_app()
+    app.state.app_state = AppState(
+        settings=_settings(public_key),
+        pocketbase=cast(PocketBaseClient, pocketbase),
+        ai=cast(AsyncOpenAI, None),
+        queue=cast(Any, redis),
+        http=cast(Any, FakeHttp()),
+    )
+    return TestClient(app)
+
+
+def _post(
+    client: TestClient, signing_key: SigningKey, payload: dict[str, Any]
+) -> httpx.Response:
+    body = json.dumps(payload).encode()
+    timestamp = "1700000000"
+    signature = signing_key.sign(timestamp.encode() + body).signature.hex()
+    return client.post(
+        "/v1/discord/interactions",
+        content=body,
+        headers={
+            "X-Signature-Ed25519": signature,
+            "X-Signature-Timestamp": timestamp,
+            "Content-Type": "application/json",
+        },
+    )
+
+
+def _command(
+    name: str,
+    options: list[dict[str, Any]] | None = None,
+    *,
+    permissions: str = "0",
+) -> dict[str, Any]:
+    return {
+        "type": 2,
+        "token": "interaction-token",
+        "guild_id": "guild1",
+        "member": {"permissions": permissions, "user": {"id": "user1"}},
+        "data": {"name": name, "options": options or []},
+    }
+
+
+@pytest.fixture
+def keypair() -> SigningKey:
+    return SigningKey.generate()
+
+
+def test_verify_accepts_valid_signature(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    body = b'{"type":1}'
+    timestamp = "123"
+    signature = keypair.sign(timestamp.encode() + body).signature.hex()
+    assert verify_signature(public_key, signature, timestamp, body) is True
+
+
+def test_verify_rejects_tampered_body(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    timestamp = "123"
+    signature = keypair.sign(timestamp.encode() + b'{"type":1}').signature.hex()
+    assert verify_signature(public_key, signature, timestamp, b'{"type":2}') is False
+
+
+def test_ping_returns_pong(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    client = _client(public_key, FakePocketBase(), FakeRedis())
+    response = _post(client, keypair, {"type": 1})
+    assert response.status_code == 200
+    assert response.json() == {"type": 1}
+
+
+def test_bad_signature_is_rejected(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    client = _client(public_key, FakePocketBase(), FakeRedis())
+    response = client.post(
+        "/v1/discord/interactions",
+        content=b'{"type":1}',
+        headers={
+            "X-Signature-Ed25519": "00" * 64,
+            "X-Signature-Timestamp": "1",
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_random_command_returns_prayer_embed(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    client = _client(public_key, FakePocketBase(), FakeRedis())
+    response = _post(client, keypair, _command("random"))
+    body = response.json()
+    assert body["type"] == 4
+    assert body["data"]["embeds"][0]["description"] == PRAYER["text"]
+    assert body["data"]["components"][0]["components"][0]["custom_id"] == "amin"
+
+
+def test_amin_button_increments(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    client = _client(public_key, FakePocketBase(), FakeRedis())
+    payload = {
+        "type": 3,
+        "token": "t",
+        "data": {"custom_id": "amin"},
+        "message": {"id": "m1", "embeds": [{"description": "x"}]},
+    }
+    body = _post(client, keypair, payload).json()
+    assert body["type"] == 7
+    assert "· 1" in body["data"]["components"][0]["components"][0]["label"]
+
+
+def test_autocomplete_returns_categories(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    client = _client(public_key, FakePocketBase(), FakeRedis())
+    payload = {
+        "type": 4,
+        "token": "t",
+        "data": {
+            "name": "random",
+            "options": [{"name": "category", "value": "", "focused": True}],
+        },
+    }
+    body = _post(client, keypair, payload).json()
+    assert body["type"] == 8
+    assert body["data"]["choices"][0]["value"] == "anxiety"
+
+
+def test_schedule_add_requires_permission(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    client = _client(public_key, FakePocketBase(), FakeRedis())
+    options = [{"name": "add", "options": [{"name": "channel", "value": "chan1"}]}]
+    body = _post(client, keypair, _command("schedule", options)).json()
+    assert body["data"]["flags"] == (1 << 6)
+    assert "صلاحية" in body["data"]["embeds"][0]["description"]
+
+
+def test_schedule_add_with_cron_creates(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    pocketbase = FakePocketBase()
+    client = _client(public_key, pocketbase, FakeRedis())
+    options = [
+        {
+            "name": "add",
+            "options": [
+                {"name": "channel", "value": "chan1"},
+                {"name": "cron", "value": "0 15 * * *"},
+            ],
+        }
+    ]
+    body = _post(
+        client, keypair, _command("schedule", options, permissions="32")
+    ).json()
+    assert body["type"] == 4
+    assert len(pocketbase.schedules) == 1
+    assert pocketbase.schedules[0]["cron"] == "0 15 * * *"
+
+
+def test_schedule_add_with_invalid_cron_is_rejected(keypair: SigningKey) -> None:
+    public_key = keypair.verify_key.encode().hex()
+    pocketbase = FakePocketBase()
+    client = _client(public_key, pocketbase, FakeRedis())
+    options = [
+        {
+            "name": "add",
+            "options": [
+                {"name": "channel", "value": "chan1"},
+                {"name": "cron", "value": "not-a-cron"},
+            ],
+        }
+    ]
+    body = _post(
+        client, keypair, _command("schedule", options, permissions="32")
+    ).json()
+    assert pocketbase.schedules == []
+    assert "cron" in body["data"]["embeds"][0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_parse_schedule_filters_invalid_cron(monkeypatch: Any) -> None:
+    async def fake_complete_json(*args: Any, **kwargs: Any) -> NLSchedule:
+        return NLSchedule(
+            crons=["0 15 * * *", "garbage"],
+            timezone="Asia/Riyadh",
+            content_type="random",
+            category=None,
+            label="afternoon",
+        )
+
+    monkeypatch.setattr(parse_module, "complete_json", fake_complete_json)
+    result = await parse_schedule(
+        cast(AsyncOpenAI, None), "model", "every day at 3pm"
+    )
+    assert result is not None
+    assert result.crons == ["0 15 * * *"]
+
+
+def test_is_due_matches_and_dedupes() -> None:
+    now = datetime(2026, 6, 5, 15, 0, tzinfo=ZoneInfo("Asia/Riyadh"))
+    schedule = Schedule(
+        id="s1",
+        guild_id="g1",
+        channel_id="c1",
+        cron="0 15 * * *",
+        timezone="Asia/Riyadh",
+        content_type="random",
+    )
+    assert _is_due(schedule, now) is True
+    schedule.last_run_at = now.isoformat()
+    assert _is_due(schedule, now) is False
+
+
+@pytest.mark.asyncio
+async def test_run_due_schedules_posts_and_marks() -> None:
+    pocketbase = FakePocketBase()
+    pocketbase.schedules.append(
+        {
+            "id": "s1",
+            "guild_id": "g1",
+            "channel_id": "c1",
+            "cron": "* * * * *",
+            "timezone": "Asia/Riyadh",
+            "content_type": "random",
+            "category": "",
+            "label": "",
+            "enabled": True,
+            "last_run_at": "",
+        }
+    )
+    http = FakeHttp(status_code=200)
+    context = WorkerContext(
+        settings=_settings("deadbeef"),
+        pocketbase=cast(PocketBaseClient, pocketbase),
+        ai=cast(AsyncOpenAI, None),
+        http=cast(Any, http),
+    )
+    await run_due_schedules(context, cast(Any, FakeRedis()))
+    assert len(http.posts) == 1
+    assert pocketbase.updated and pocketbase.updated[0][0] == "s1"

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,14 +34,16 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.6"
+version = "0.1.7"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },
+    { name = "croniter" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "openai" },
     { name = "pydantic-settings" },
+    { name = "pynacl" },
     { name = "redis" },
     { name = "slowapi" },
     { name = "uvicorn", extra = ["standard"] },
@@ -53,15 +55,18 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-croniter" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "arq", specifier = "==0.28.0" },
+    { name = "croniter", specifier = ">=6.2.2" },
     { name = "fastapi", specifier = "==0.136.3" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "openai", specifier = "==1.59.6" },
     { name = "pydantic-settings", specifier = "==2.7.0" },
+    { name = "pynacl", specifier = ">=1.6.2" },
     { name = "redis", specifier = "==5.2.1" },
     { name = "slowapi", specifier = "==0.1.9" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.48.0" },
@@ -73,6 +78,7 @@ dev = [
     { name = "pytest", specifier = "==8.3.4" },
     { name = "pytest-asyncio", specifier = "==0.25.2" },
     { name = "ruff", specifier = "==0.8.6" },
+    { name = "types-croniter", specifier = ">=6.2.2.20260518" },
 ]
 
 [[package]]
@@ -98,6 +104,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -116,6 +155,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]
@@ -377,6 +428,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -446,6 +506,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -470,6 +565,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950, upload-time = "2025-01-08T06:20:29.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400, upload-time = "2025-01-08T06:20:27.862Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -547,6 +654,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "slowapi"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -589,6 +705,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "types-croniter"
+version = "6.2.2.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/02/f03a44ded34e6abb125c339647b070f2705a0583782f5638d62ab958cdc2/types_croniter-6.2.2.20260518.tar.gz", hash = "sha256:aceb426b9187bb9255b89d17713d07ac034a2b96b437bfdd5d3a56b46b4eb656", size = 12120, upload-time = "2026-05-18T06:03:11.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/3d/f12c417944d00c42db71de3e334f36a69cafa6767ff3fb705c9e1d101e53/types_croniter-6.2.2.20260518-py3-none-any.whl", hash = "sha256:85018c7ce091428d3643be239ad348e27f9a8fb77ca94335cc39ebeb9403b240", size = 9743, upload-time = "2026-05-18T06:03:10.608Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

A Discord bot for ad3oni built entirely on the **existing** web + worker processes — no new always-on service.

- **Inbound:** a signed `POST /v1/discord/interactions` route on the web process. Verifies Discord's Ed25519 signature over the raw body, answers the PING handshake, and responds to slash commands / buttons / autocomplete **inline** within the 3s deadline. Reuses `DailyService` / `PrayerService` / `TaxonomyService` in-process (no HTTP hop, no self-rate-limiting).
- **Outbound:** a once-a-minute worker cron (`dispatch_schedules`) posts whatever schedules are due to their channels via the bot token. The 00:00 Mecca daily-assignment cron stays as the source of the prayer of the day.

## Commands

`/daily`, `/random [category]` (live category **autocomplete**), `/search`, `/categories`, `/submit` (into the AI ingestion pipeline, with a per-user cooldown), `/help`, plus the scheduler:

- `/setup-daily #channel` — preset: posts the prayer of the day daily at 00:01 Mecca.
- `/schedule add #channel` — supply **either** `cron:` (validated inline) **or** `when:` natural language ("every day at 3pm and 6pm") which the existing Groq structured-output AI parses into cron(s), each validated with `croniter` and echoed back before running.
- `/schedule list | remove`.

Every prayer post (command / daily / scheduled) carries a 🤲 **آمين** button backed by a Redis counter.

## Storage & safety

- One new PocketBase `schedules` collection (added idempotently via `apply_pb_schema.py`; already applied to prod).
- **Inert until configured:** the endpoint 401s without `DISCORD_PUBLIC_KEY`, and the scheduler early-returns without `DISCORD_BOT_TOKEN` — so this deploys safely with no env set.
- Multi-server: each guild registers its own channels (MANAGE_GUILD gated). Dynamic schedules run via a minute-tick + `croniter` + `last_run_at` dedupe (no per-schedule arq jobs; survives restarts). Self-heals: a 403/404 on post disables that schedule.
- New deps: `pynacl`, `croniter`.

## Verified

- `ruff` + `mypy` clean (103 files), **49 pytest** pass (20 new: signature verify/tamper, PING, 401, `/random` embed, آمين increment, autocomplete, MANAGE_GUILD gate, cron create + invalid-cron reject, NL parse filtering invalid crons, `_is_due` match/dedupe, scheduler posts+marks).

## Remaining (needs the bot token)

The owner provided the public key + app id (`1159198588782518292`). The third value shared was a **client secret**, which can't post messages or register commands — the **bot token** (Developer Portal → Bot → Reset Token) is still needed. Once it's in Infisical/Coolify: register commands (`scripts/register_discord_commands.py`), set the Interactions Endpoint URL to `https://api.ad3oni.com/v1/discord/interactions`, and the bot goes live.