### PR TITLE
feat(api): daily prayer at 8am Mecca + remove /categories

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.8"
+version = "0.1.9"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/discord/commands.py
+++ b/apps/api/src/features/discord/commands.py
@@ -62,7 +62,6 @@ def command_definitions() -> list[dict[str, Any]]:
                 },
             ],
         },
-        {"name": "categories", "description": "Browse the du'a categories"},
         {
             "name": "submit",
             "description": "Submit a new du'a for review",

--- a/apps/api/src/features/discord/embeds.py
+++ b/apps/api/src/features/discord/embeds.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from src.features.prayers.schema import Prayer
-from src.features.taxonomy.schema import Category
 
 BRAND_COLOR = 0x6D5ACD
 SITE_URL = "https://ad3oni.com"
@@ -55,7 +54,6 @@ def help_embed() -> dict[str, Any]:
             "• `/daily` — دعاء اليوم\n"
             "• `/random` — دعاء عشوائي (يمكن تحديد التصنيف)\n"
             "• `/search` — البحث في الأدعية\n"
-            "• `/categories` — تصفّح التصنيفات\n"
             "• `/submit` — إرسال دعاء جديد للمراجعة\n"
             "• `/setup-daily` — نشر دعاء اليوم تلقائيًا في قناة\n"
             "• `/schedule` — جدولة نشر الأدعية بوقت محدد أو بصيغة cron"
@@ -67,19 +65,3 @@ def help_embed() -> dict[str, Any]:
 
 def info_embed(message: str) -> dict[str, Any]:
     return {"description": message, "color": BRAND_COLOR}
-
-
-def categories_embed(categories: list[Category]) -> dict[str, Any]:
-    groups: dict[str, list[str]] = {}
-    for category in categories:
-        group_name = category.group.name if category.group else "أخرى"
-        groups.setdefault(group_name, []).append(category.name)
-    sections = [
-        f"**{group_name}**\n{'، '.join(names)}"
-        for group_name, names in groups.items()
-    ]
-    return {
-        "title": "التصنيفات",
-        "description": "\n\n".join(sections),
-        "color": BRAND_COLOR,
-    }

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -10,7 +10,6 @@ from openai import AsyncOpenAI
 from src.features.daily.service import DailyService
 from src.features.discord.embeds import (
     amin_components,
-    categories_embed,
     help_embed,
     info_embed,
     prayer_embed,
@@ -40,7 +39,7 @@ from src.shared.config.settings import Settings
 from src.shared.errors.exceptions import NotFoundError, ValidationError
 from src.shared.pocketbase.client import PocketBaseClient
 
-_DAILY_CRON = "1 0 * * *"
+_DAILY_CRON = "0 8 * * *"
 _SUBMIT_COOLDOWN_SECONDS = 30
 _SEARCH_LIMIT = 3
 
@@ -155,8 +154,6 @@ async def _handle_command(
         return await _handle_random(deps, options)
     if name == "search":
         return await _handle_search(deps, options)
-    if name == "categories":
-        return await _handle_categories(deps)
     if name == "submit":
         return await _handle_submit(payload, deps, options)
     if name == "help":
@@ -209,12 +206,6 @@ async def _handle_search(
     return InteractionResult(_message(embeds))
 
 
-async def _handle_categories(deps: DiscordDeps) -> InteractionResult:
-    service = TaxonomyService(deps.pocketbase)
-    categories = await service.list_categories()
-    return InteractionResult(_message([categories_embed(categories)], ephemeral=True))
-
-
 async def _handle_submit(
     payload: dict[str, Any], deps: DiscordDeps, options: dict[str, Any]
 ) -> InteractionResult:
@@ -264,7 +255,7 @@ async def _handle_setup_daily(
         return InteractionResult(_ephemeral(error.message))
     return InteractionResult(
         _ephemeral(
-            f"سيُنشر دعاء اليوم في <#{channel_id}> يوميًا الساعة 12:01 منتصف الليل (توقيت مكة).\n"
+            f"سيُنشر دعاء اليوم في <#{channel_id}> يوميًا الساعة الثامنة صباحًا (توقيت مكة).\n"
             f"`{created.id}`"
         )
     )

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.7"
+version = "0.1.9"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Two Discord tweaks.

## 1. Daily prayer posts at 8 AM Mecca
`/setup-daily` now creates the schedule with cron `0 8 * * *` (Asia/Riyadh), up from `1 0 * * *` (00:01). Confirmation copy updated to "الساعة الثامنة صباحًا". The one already-configured daily schedule was migrated in the database, so it takes effect immediately without waiting on this deploy.

## 2. Remove the /categories command
Removed the `/categories` slash command — its definition, handler, dispatch, the `/help` listing, and the now-unused categories embed (and its dead import). Commands were re-registered live (7 remain: daily, random, search, submit, help, setup-daily, schedule). Category **autocomplete** and `/random category:` are unaffected.

Gates: ruff + mypy (103 files) + 49 tests green.