### PR TITLE
feat(api): simplify the Discord prayer message

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.9"
+version = "0.1.10"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/discord/embeds.py
+++ b/apps/api/src/features/discord/embeds.py
@@ -7,43 +7,7 @@ SITE_URL = "https://ad3oni.com"
 
 
 def prayer_embed(prayer: Prayer) -> dict[str, Any]:
-    footer_parts = [
-        part
-        for part in (
-            prayer.source,
-            prayer.category.name if prayer.category else None,
-            prayer.type.name if prayer.type else None,
-        )
-        if part
-    ]
-    embed: dict[str, Any] = {
-        "description": prayer.text,
-        "color": BRAND_COLOR,
-        "url": SITE_URL,
-    }
-    if prayer.category:
-        embed["title"] = prayer.category.name
-    if footer_parts:
-        embed["footer"] = {"text": " · ".join(footer_parts)}
-    return embed
-
-
-def amin_components(count: int) -> list[dict[str, Any]]:
-    label = "آمين" if count <= 0 else f"آمين · {count}"
-    return [
-        {
-            "type": 1,
-            "components": [
-                {
-                    "type": 2,
-                    "style": 1,
-                    "label": label,
-                    "emoji": {"name": "🤲"},
-                    "custom_id": "amin",
-                }
-            ],
-        }
-    ]
+    return {"description": f"**﴿ {prayer.text} ﴾**", "color": BRAND_COLOR}
 
 
 def help_embed() -> dict[str, Any]:

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -1,6 +1,6 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import httpx
 from arq import ArqRedis
@@ -9,7 +9,6 @@ from openai import AsyncOpenAI
 
 from src.features.daily.service import DailyService
 from src.features.discord.embeds import (
-    amin_components,
     help_embed,
     info_embed,
     prayer_embed,
@@ -20,12 +19,11 @@ from src.features.discord.keys import (
     APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
     CHANNEL_MESSAGE_WITH_SOURCE,
     DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+    DEFERRED_UPDATE_MESSAGE,
     EPHEMERAL_FLAG,
     MANAGE_GUILD,
     MESSAGE_COMPONENT,
     PONG,
-    UPDATE_MESSAGE,
-    amin_count_key,
     submit_cooldown_key,
 )
 from src.features.discord.parse import DEFAULT_TIMEZONE, parse_schedule
@@ -60,14 +58,9 @@ class InteractionResult:
 
 
 def _message(
-    embeds: list[dict[str, Any]],
-    components: list[dict[str, Any]] | None = None,
-    *,
-    ephemeral: bool = False,
+    embeds: list[dict[str, Any]], *, ephemeral: bool = False
 ) -> dict[str, Any]:
     data: dict[str, Any] = {"embeds": embeds}
-    if components is not None:
-        data["components"] = components
     if ephemeral:
         data["flags"] = EPHEMERAL_FLAG
     return {"type": CHANNEL_MESSAGE_WITH_SOURCE, "data": data}
@@ -171,9 +164,7 @@ async def _handle_daily(deps: DiscordDeps) -> InteractionResult:
         prayer = await service.get_daily()
     except NotFoundError:
         return InteractionResult(_ephemeral("لا توجد أدعية متاحة بعد."))
-    return InteractionResult(
-        _message([prayer_embed(prayer)], amin_components(0))
-    )
+    return InteractionResult(_message([prayer_embed(prayer)]))
 
 
 async def _handle_random(
@@ -186,9 +177,7 @@ async def _handle_random(
         )
     except NotFoundError:
         return InteractionResult(_ephemeral("لا توجد أدعية مطابقة."))
-    return InteractionResult(
-        _message([prayer_embed(prayer)], amin_components(0))
-    )
+    return InteractionResult(_message([prayer_embed(prayer)]))
 
 
 async def _handle_search(
@@ -399,20 +388,7 @@ async def _handle_schedule_remove(
 async def _handle_component(
     payload: dict[str, Any], deps: DiscordDeps
 ) -> InteractionResult:
-    custom_id = payload["data"].get("custom_id")
-    message = payload.get("message", {})
-    embeds = message.get("embeds", [])
-    if custom_id != "amin":
-        return InteractionResult({"type": UPDATE_MESSAGE, "data": {"embeds": embeds}})
-    count = await cast(
-        "Awaitable[int]", deps.queue.incr(amin_count_key(message.get("id", "")))
-    )
-    return InteractionResult(
-        {
-            "type": UPDATE_MESSAGE,
-            "data": {"embeds": embeds, "components": amin_components(count)},
-        }
-    )
+    return InteractionResult({"type": DEFERRED_UPDATE_MESSAGE})
 
 
 async def _handle_autocomplete(

--- a/apps/api/src/features/discord/keys.py
+++ b/apps/api/src/features/discord/keys.py
@@ -10,16 +10,10 @@ APPLICATION_COMMAND_AUTOCOMPLETE = 4
 PONG = 1
 CHANNEL_MESSAGE_WITH_SOURCE = 4
 DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
-UPDATE_MESSAGE = 7
+DEFERRED_UPDATE_MESSAGE = 6
 APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8
 
 EPHEMERAL_FLAG = 1 << 6
-
-AMIN_BUTTON_PREFIX = "amin"
-
-
-def amin_count_key(message_id: str) -> str:
-    return f"ad3oni:discord:amin:{message_id}"
 
 
 def submit_cooldown_key(user_id: str) -> str:

--- a/apps/api/src/features/discord/rest.py
+++ b/apps/api/src/features/discord/rest.py
@@ -15,18 +15,12 @@ class DiscordRest:
         return {"Authorization": f"Bot {self._token}"}
 
     async def post_message(
-        self,
-        channel_id: str,
-        embed: dict[str, Any],
-        components: list[dict[str, Any]] | None = None,
+        self, channel_id: str, embed: dict[str, Any]
     ) -> httpx.Response:
-        payload: dict[str, Any] = {"embeds": [embed]}
-        if components is not None:
-            payload["components"] = components
         return await self._http.post(
             f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
             headers=self._headers,
-            json=payload,
+            json={"embeds": [embed]},
         )
 
     async def edit_original(

--- a/apps/api/src/features/discord/scheduler.py
+++ b/apps/api/src/features/discord/scheduler.py
@@ -5,7 +5,7 @@ from arq import ArqRedis
 from croniter import croniter
 
 from src.features.daily.service import DailyService
-from src.features.discord.embeds import amin_components, prayer_embed
+from src.features.discord.embeds import prayer_embed
 from src.features.discord.rest import DiscordRest
 from src.features.discord.schema import Schedule
 from src.features.discord.service import DiscordScheduleService
@@ -70,7 +70,7 @@ async def run_due_schedules(context: WorkerContext, redis: ArqRedis) -> None:
             continue
 
         response = await rest.post_message(
-            schedule.channel_id, prayer_embed(prayer), amin_components(0)
+            schedule.channel_id, prayer_embed(prayer)
         )
         if response.status_code in (403, 404):
             await service.disable(schedule.id)

--- a/apps/api/tests/test_discord.py
+++ b/apps/api/tests/test_discord.py
@@ -229,28 +229,30 @@ def test_bad_signature_is_rejected(keypair: SigningKey) -> None:
     assert response.status_code == 401
 
 
-def test_random_command_returns_prayer_embed(keypair: SigningKey) -> None:
+def test_random_command_returns_minimal_prayer_embed(keypair: SigningKey) -> None:
     public_key = keypair.verify_key.encode().hex()
     client = _client(public_key, FakePocketBase(), FakeRedis())
     response = _post(client, keypair, _command("random"))
     body = response.json()
     assert body["type"] == 4
-    assert body["data"]["embeds"][0]["description"] == PRAYER["text"]
-    assert body["data"]["components"][0]["components"][0]["custom_id"] == "amin"
+    embed = body["data"]["embeds"][0]
+    assert embed["description"] == f"**﴿ {PRAYER['text']} ﴾**"
+    assert "title" not in embed
+    assert "footer" not in embed
+    assert "components" not in body["data"]
 
 
-def test_amin_button_increments(keypair: SigningKey) -> None:
+def test_component_interaction_is_acknowledged(keypair: SigningKey) -> None:
     public_key = keypair.verify_key.encode().hex()
     client = _client(public_key, FakePocketBase(), FakeRedis())
     payload = {
         "type": 3,
         "token": "t",
         "data": {"custom_id": "amin"},
-        "message": {"id": "m1", "embeds": [{"description": "x"}]},
+        "message": {"id": "m1"},
     }
     body = _post(client, keypair, payload).json()
-    assert body["type"] == 7
-    assert "· 1" in body["data"]["components"][0]["components"][0]["label"]
+    assert body["type"] == 6
 
 
 def test_autocomplete_returns_categories(keypair: SigningKey) -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.9"
+version = "0.1.10"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Makes the bot's prayer message minimal, per the design pass.

**Before:** embed with a title (category), the du'a, a footer (source · category · type), and an آمين counter button.

**After:** just the du'a — bold, wrapped in the Quranic ornaments ﴿ ﴾, on the violet embed bar. No title, no footer, no button.

Applies to `/daily`, `/random`, and the scheduled/daily auto-posts. `/search` stays as text embeds (multiple, copyable results). Legacy آمين buttons on already-posted messages are acknowledged as a no-op (no "interaction failed"). Removes the old title/footer embed fields and the button + Redis counter.

Note: text-only by design — Discord can't render a custom font for all viewers (confirmed: no font field in embeds, no font embedding, and the Unicode "fancy font" trick doesn't exist for Arabic). The only true-custom-font route is rendering an image, which we chose not to use here to keep the du'a copyable.

Gates: ruff + mypy (103 files) + 49 tests green.