### PR TITLE
feat(api): Arabic schedule listings in Discord

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.10"
+version = "0.1.11"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/discord/describe.py
+++ b/apps/api/src/features/discord/describe.py
@@ -1,0 +1,119 @@
+_AR_DIGITS = str.maketrans("0123456789", "٠١٢٣٤٥٦٧٨٩")
+
+_WEEKDAYS = {
+    0: "الأحد",
+    7: "الأحد",
+    1: "الإثنين",
+    2: "الثلاثاء",
+    3: "الأربعاء",
+    4: "الخميس",
+    5: "الجمعة",
+    6: "السبت",
+}
+
+_TIMEZONE_CITIES = {
+    "Asia/Riyadh": "مكة",
+    "Asia/Dubai": "دبي",
+    "Asia/Qatar": "الدوحة",
+    "Asia/Kuwait": "الكويت",
+    "Asia/Bahrain": "المنامة",
+    "Asia/Muscat": "مسقط",
+    "Asia/Baghdad": "بغداد",
+    "Asia/Amman": "عمّان",
+    "Asia/Beirut": "بيروت",
+    "Asia/Damascus": "دمشق",
+    "Asia/Jerusalem": "القدس",
+    "Asia/Aden": "عدن",
+    "Africa/Cairo": "القاهرة",
+    "Africa/Khartoum": "الخرطوم",
+    "Africa/Casablanca": "الدار البيضاء",
+    "Africa/Tunis": "تونس",
+    "Africa/Algiers": "الجزائر",
+    "Africa/Tripoli": "طرابلس",
+    "Africa/Nouakchott": "نواكشوط",
+    "Africa/Mogadishu": "مقديشو",
+}
+
+
+def _ar(number: int) -> str:
+    return str(number).translate(_AR_DIGITS)
+
+
+def _ar2(number: int) -> str:
+    return f"{number:02d}".translate(_AR_DIGITS)
+
+
+def _clock(minute: int, hour: int) -> str:
+    if minute == 0 and hour == 0:
+        return "منتصف الليل"
+    if minute == 0 and hour == 12:
+        return "ظهرًا"
+    period = "صباحًا" if hour < 12 else ("ظهرًا" if hour == 12 else "مساءً")
+    hour12 = hour % 12 or 12
+    clock = _ar(hour12) if minute == 0 else f"{_ar(hour12)}:{_ar2(minute)}"
+    return f"{clock} {period}"
+
+
+def _time_phrase(minute: int, hours: list[int]) -> str:
+    if len(hours) == 1:
+        clock = _clock(minute, hours[0])
+        return clock if clock in ("منتصف الليل", "ظهرًا") else f"الساعة {clock}"
+    return "الساعة " + " و".join(_clock(minute, hour) for hour in hours)
+
+
+def describe_cron_ar(cron: str) -> str | None:
+    parts = cron.split()
+    if len(parts) != 5:
+        return None
+    minute_field, hour_field, dom_field, month_field, dow_field = parts
+    if month_field != "*" or not minute_field.isdigit():
+        return None
+
+    minute = int(minute_field)
+    if minute > 59:
+        return None
+    try:
+        hours = [int(value) for value in hour_field.split(",")]
+    except ValueError:
+        return None
+    if any(hour > 23 for hour in hours):
+        return None
+
+    time_phrase = _time_phrase(minute, hours)
+
+    if dom_field == "*" and dow_field == "*":
+        day_phrase = "كل يوم"
+    elif dom_field == "*":
+        try:
+            days = [int(value) for value in dow_field.split(",")]
+        except ValueError:
+            return None
+        names = [_WEEKDAYS.get(day) for day in days]
+        if any(name is None for name in names):
+            return None
+        if len(names) == 1 and names[0] is not None:
+            day_phrase = f"كل {names[0].removeprefix('ال')}"
+        else:
+            day_phrase = "أيام " + " و".join(name for name in names if name)
+    elif dow_field == "*" and dom_field.isdigit():
+        day_phrase = f"يوم {_ar(int(dom_field))} من كل شهر"
+    else:
+        return None
+
+    return f"{day_phrase} {time_phrase}"
+
+
+def timezone_label_ar(timezone: str) -> str:
+    city = _TIMEZONE_CITIES.get(timezone)
+    if city:
+        return f"بتوقيت {city}"
+    tail = timezone.split("/")[-1].replace("_", " ")
+    return f"بتوقيت {tail}"
+
+
+def content_label_ar(content_type: str, category_display: str | None) -> str:
+    if content_type == "daily":
+        return "دعاء اليوم"
+    if content_type == "category" and category_display:
+        return f"دعاء من تصنيف {category_display}"
+    return "دعاء عشوائي"

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -8,6 +8,11 @@ from croniter import croniter
 from openai import AsyncOpenAI
 
 from src.features.daily.service import DailyService
+from src.features.discord.describe import (
+    content_label_ar,
+    describe_cron_ar,
+    timezone_label_ar,
+)
 from src.features.discord.embeds import (
     help_embed,
     info_embed,
@@ -104,20 +109,34 @@ def _focused_option(data: dict[str, Any]) -> dict[str, Any] | None:
     return walk(data.get("options", []))
 
 
-def _schedule_summary(schedule: Schedule) -> str:
-    target = (
-        f"category: {schedule.category}"
-        if schedule.content_type == "category" and schedule.category
-        else schedule.content_type
+async def _category_names(
+    deps: DiscordDeps, schedules: list[Schedule]
+) -> dict[str, str]:
+    if not any(s.content_type == "category" and s.category for s in schedules):
+        return {}
+    categories = await TaxonomyService(deps.pocketbase).list_categories()
+    return {category.slug: category.name for category in categories}
+
+
+def _schedule_summary(schedule: Schedule, category_names: dict[str, str]) -> str:
+    when = describe_cron_ar(schedule.cron) or f"وفق الجدولة `{schedule.cron}`"
+    category_display = category_names.get(
+        schedule.category or "", schedule.category or ""
     )
+    content = content_label_ar(schedule.content_type, category_display)
     return (
-        f"• `{schedule.id}` — `{schedule.cron}` ({schedule.timezone}) → "
-        f"{target} in <#{schedule.channel_id}>"
+        f"• **{content}** — {when} {timezone_label_ar(schedule.timezone)} — "
+        f"في <#{schedule.channel_id}>\n"
+        f"المعرّف: `{schedule.id}` · `{schedule.cron}`"
     )
 
 
-def _confirm_created(schedules: list[Schedule]) -> str:
-    lines = "\n".join(_schedule_summary(schedule) for schedule in schedules)
+def _confirm_created(
+    schedules: list[Schedule], category_names: dict[str, str]
+) -> str:
+    lines = "\n\n".join(
+        _schedule_summary(schedule, category_names) for schedule in schedules
+    )
     return f"تمت إضافة الجدولة:\n{lines}"
 
 
@@ -301,7 +320,8 @@ async def _handle_schedule_add(
             )
         except ValidationError as error:
             return InteractionResult(_ephemeral(error.message))
-        return InteractionResult(_ephemeral(_confirm_created([created])))
+        names = await _category_names(deps, [created])
+        return InteractionResult(_ephemeral(_confirm_created([created], names)))
 
     if when:
         return InteractionResult(
@@ -356,7 +376,10 @@ def _schedule_add_background(
         except ValidationError as error:
             await rest.edit_original(app_id, token, info_embed(error.message))
             return
-        await rest.edit_original(app_id, token, info_embed(_confirm_created(created)))
+        names = await _category_names(deps, created)
+        await rest.edit_original(
+            app_id, token, info_embed(_confirm_created(created, names))
+        )
 
     return run
 
@@ -369,7 +392,10 @@ async def _handle_schedule_list(
     schedules = await service.list_for_guild(guild_id)
     if not schedules:
         return InteractionResult(_ephemeral("لا توجد جدولات في هذا الخادم."))
-    body = "\n".join(_schedule_summary(schedule) for schedule in schedules)
+    names = await _category_names(deps, schedules)
+    body = "\n\n".join(
+        _schedule_summary(schedule, names) for schedule in schedules
+    )
     return InteractionResult(_message([info_embed(body)], ephemeral=True))
 
 

--- a/apps/api/tests/test_discord.py
+++ b/apps/api/tests/test_discord.py
@@ -9,6 +9,11 @@ from fastapi.testclient import TestClient
 from nacl.signing import SigningKey
 from openai import AsyncOpenAI
 from src.features.discord import parse as parse_module
+from src.features.discord.describe import (
+    content_label_ar,
+    describe_cron_ar,
+    timezone_label_ar,
+)
 from src.features.discord.parse import NLSchedule, parse_schedule
 from src.features.discord.scheduler import _is_due, run_due_schedules
 from src.features.discord.schema import Schedule
@@ -240,6 +245,23 @@ def test_random_command_returns_minimal_prayer_embed(keypair: SigningKey) -> Non
     assert "title" not in embed
     assert "footer" not in embed
     assert "components" not in body["data"]
+
+
+def test_describe_cron_ar() -> None:
+    assert describe_cron_ar("0 8 * * *") == "كل يوم الساعة ٨ صباحًا"
+    assert describe_cron_ar("18 19 * * *") == "كل يوم الساعة ٧:١٨ مساءً"
+    assert describe_cron_ar("0 12 * * *") == "كل يوم ظهرًا"
+    assert describe_cron_ar("0 0 * * *") == "كل يوم منتصف الليل"
+    assert describe_cron_ar("30 6 * * 5") == "كل جمعة الساعة ٦:٣٠ صباحًا"
+    assert describe_cron_ar("*/15 * * * *") is None
+
+
+def test_timezone_and_content_labels() -> None:
+    assert timezone_label_ar("Asia/Riyadh") == "بتوقيت مكة"
+    assert timezone_label_ar("Africa/Cairo") == "بتوقيت القاهرة"
+    assert content_label_ar("daily", None) == "دعاء اليوم"
+    assert content_label_ar("random", None) == "دعاء عشوائي"
+    assert content_label_ar("category", "الرزق") == "دعاء من تصنيف الرزق"
 
 
 def test_component_interaction_is_acknowledged(keypair: SigningKey) -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.10"
+version = "0.1.11"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Makes `/schedule list` (and the add / natural-language confirmations) fully Arabic.

**Before:** `• 57idmgarivwx5cz — 0 8 * * * (Asia/Riyadh) → daily in #general`

**After:**
```
• دعاء اليوم — كل يوم الساعة ٨ صباحًا بتوقيت مكة — في #general
  المعرّف: 57idmgarivwx5cz · 0 8 * * *
```

- Human Arabic time from the cron (`كل يوم الساعة ٨ صباحًا`, `كل يوم الساعة ٧:١٨ مساءً`, `ظهرًا`, `منتصف الليل`, weekly/monthly).
- `بتوقيت مكة` instead of `Asia/Riyadh` (Gulf/Arab timezones mapped to Arabic city names).
- Arabic content labels: `دعاء اليوم` / `دعاء عشوائي` / `دعاء من تصنيف <name>` (category slug resolved to its Arabic name).
- Raw cron + id kept as a small second-line detail so `/schedule remove` still has the id.
- New `describe.py` handles common cron patterns and falls back to `وفق الجدولة \`<cron>\`` for exotic ones.

Gates: ruff + mypy (104 files) + 51 tests green.