### PR TITLE
feat(api): compact one-line Discord schedule listings

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.11"
+version = "0.1.12"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -125,16 +125,15 @@ def _schedule_summary(schedule: Schedule, category_names: dict[str, str]) -> str
     )
     content = content_label_ar(schedule.content_type, category_display)
     return (
-        f"• **{content}** — {when} {timezone_label_ar(schedule.timezone)} — "
-        f"في <#{schedule.channel_id}>\n"
-        f"المعرّف: `{schedule.id}` · `{schedule.cron}`"
+        f"- `{schedule.id}` - {content} {when} "
+        f"{timezone_label_ar(schedule.timezone)} في <#{schedule.channel_id}>"
     )
 
 
 def _confirm_created(
     schedules: list[Schedule], category_names: dict[str, str]
 ) -> str:
-    lines = "\n\n".join(
+    lines = "\n".join(
         _schedule_summary(schedule, category_names) for schedule in schedules
     )
     return f"تمت إضافة الجدولة:\n{lines}"
@@ -393,9 +392,7 @@ async def _handle_schedule_list(
     if not schedules:
         return InteractionResult(_ephemeral("لا توجد جدولات في هذا الخادم."))
     names = await _category_names(deps, schedules)
-    body = "\n\n".join(
-        _schedule_summary(schedule, names) for schedule in schedules
-    )
+    body = "\n".join(_schedule_summary(schedule, names) for schedule in schedules)
     return InteractionResult(_message([info_embed(body)], ephemeral=True))
 
 

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.11"
+version = "0.1.12"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Reverts the schedule listing to a single compact line per the old layout, but in Arabic:

```
- `57idmgarivwx5cz` - دعاء اليوم كل يوم الساعة ٨ صباحًا بتوقيت مكة في #general
```

`- ` bullet, id in code block, the simple Arabic message (content + time + بتوقيت مكة), then في #channel. Drops the second id/cron detail line and the em dashes. Complex crons still fall back to the inline raw expression.

Gates: ruff + mypy (104 files) + 51 tests green.