### PR TITLE
fix(api): isolate bidi in Discord schedule listings

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.12"
+version = "0.1.13"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/discord/describe.py
+++ b/apps/api/src/features/discord/describe.py
@@ -1,4 +1,16 @@
+_RLM = chr(0x200F)
+_FSI = chr(0x2068)
+_PDI = chr(0x2069)
+
 _AR_DIGITS = str.maketrans("0123456789", "٠١٢٣٤٥٦٧٨٩")
+
+
+def isolate(text: str) -> str:
+    return f"{_FSI}{text}{_PDI}"
+
+
+def force_rtl(text: str) -> str:
+    return f"{_RLM}{text}"
 
 _WEEKDAYS = {
     0: "الأحد",

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -11,6 +11,8 @@ from src.features.daily.service import DailyService
 from src.features.discord.describe import (
     content_label_ar,
     describe_cron_ar,
+    force_rtl,
+    isolate,
     timezone_label_ar,
 )
 from src.features.discord.embeds import (
@@ -124,10 +126,13 @@ def _schedule_summary(schedule: Schedule, category_names: dict[str, str]) -> str
         schedule.category or "", schedule.category or ""
     )
     content = content_label_ar(schedule.content_type, category_display)
-    return (
-        f"- `{schedule.id}` - {content} {when} "
-        f"{timezone_label_ar(schedule.timezone)} في <#{schedule.channel_id}>"
+    channel = isolate(f"<#{schedule.channel_id}>")
+    identifier = isolate(f"`{schedule.id}`")
+    body = (
+        f"{identifier} - {content} {when} "
+        f"{timezone_label_ar(schedule.timezone)} في {channel}"
     )
+    return f"- {force_rtl(body)}"
 
 
 def _confirm_created(
@@ -260,10 +265,11 @@ async def _handle_setup_daily(
         )
     except ValidationError as error:
         return InteractionResult(_ephemeral(error.message))
+    channel = isolate(f"<#{channel_id}>")
     return InteractionResult(
         _ephemeral(
-            f"سيُنشر دعاء اليوم في <#{channel_id}> يوميًا الساعة الثامنة صباحًا (توقيت مكة).\n"
-            f"`{created.id}`"
+            f"سيُنشر دعاء اليوم في {channel} يوميًا الساعة الثامنة صباحًا "
+            f"(توقيت مكة).\n{isolate(f'`{created.id}`')}"
         )
     )
 

--- a/apps/api/tests/test_discord.py
+++ b/apps/api/tests/test_discord.py
@@ -256,6 +256,25 @@ def test_describe_cron_ar() -> None:
     assert describe_cron_ar("*/15 * * * *") is None
 
 
+def test_schedule_summary_isolates_bidi() -> None:
+    from src.features.discord import handlers
+    from src.features.discord.schema import Schedule
+
+    schedule = Schedule(
+        id="abc123",
+        guild_id="g",
+        channel_id="555",
+        cron="0 8 * * *",
+        timezone="Asia/Riyadh",
+        content_type="daily",
+    )
+    rlm, fsi, pdi = chr(0x200F), chr(0x2068), chr(0x2069)
+    summary = handlers._schedule_summary(schedule, {})
+    assert summary.startswith(f"- {rlm}")
+    assert f"{fsi}<#555>{pdi}" in summary
+    assert f"{fsi}`abc123`{pdi}" in summary
+
+
 def test_timezone_and_content_labels() -> None:
     assert timezone_label_ar("Asia/Riyadh") == "بتوقيت مكة"
     assert timezone_label_ar("Africa/Cairo") == "بتوقيت القاهرة"

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.12"
+version = "0.1.13"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
The `/schedule list` line started with a Latin id, so Discord resolved the whole line to **LTR base direction**, mis-ordering the Arabic and the `في #channel` part — and the channel mention shifted depending on whether the channel name is Latin or Arabic.

Fix (the Unicode equivalent of HTML `<bdi>`): wrap the id and the channel mention in **bidi isolates** (`U+2068 FSI` … `U+2069 PDI`) and prefix an `U+200F RLM` to force RTL base. The line now reads right-to-left correctly and is independent of the channel name's script. Applied to `/schedule list`, the add / `when:` confirmations, and `/setup-daily`.

Gates: ruff + mypy (104 files) + 52 tests green (incl. a regression test asserting the isolates).