### PR TITLE
fix(api): keep schedule id at the front with RTL-isolated message

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.13"
+version = "0.1.14"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/discord/describe.py
+++ b/apps/api/src/features/discord/describe.py
@@ -1,4 +1,4 @@
-_RLM = chr(0x200F)
+_RLI = chr(0x2067)
 _FSI = chr(0x2068)
 _PDI = chr(0x2069)
 
@@ -9,8 +9,8 @@ def isolate(text: str) -> str:
     return f"{_FSI}{text}{_PDI}"
 
 
-def force_rtl(text: str) -> str:
-    return f"{_RLM}{text}"
+def rtl_block(text: str) -> str:
+    return f"{_RLI}{text}{_PDI}"
 
 _WEEKDAYS = {
     0: "الأحد",

--- a/apps/api/src/features/discord/handlers.py
+++ b/apps/api/src/features/discord/handlers.py
@@ -11,8 +11,8 @@ from src.features.daily.service import DailyService
 from src.features.discord.describe import (
     content_label_ar,
     describe_cron_ar,
-    force_rtl,
     isolate,
+    rtl_block,
     timezone_label_ar,
 )
 from src.features.discord.embeds import (
@@ -127,12 +127,10 @@ def _schedule_summary(schedule: Schedule, category_names: dict[str, str]) -> str
     )
     content = content_label_ar(schedule.content_type, category_display)
     channel = isolate(f"<#{schedule.channel_id}>")
-    identifier = isolate(f"`{schedule.id}`")
-    body = (
-        f"{identifier} - {content} {when} "
-        f"{timezone_label_ar(schedule.timezone)} في {channel}"
+    message = rtl_block(
+        f"{content} {when} {timezone_label_ar(schedule.timezone)} في {channel}"
     )
-    return f"- {force_rtl(body)}"
+    return f"- `{schedule.id}` - {message}"
 
 
 def _confirm_created(

--- a/apps/api/tests/test_discord.py
+++ b/apps/api/tests/test_discord.py
@@ -268,11 +268,11 @@ def test_schedule_summary_isolates_bidi() -> None:
         timezone="Asia/Riyadh",
         content_type="daily",
     )
-    rlm, fsi, pdi = chr(0x200F), chr(0x2068), chr(0x2069)
+    rli, fsi, pdi = chr(0x2067), chr(0x2068), chr(0x2069)
     summary = handlers._schedule_summary(schedule, {})
-    assert summary.startswith(f"- {rlm}")
+    assert summary.startswith(f"- `abc123` - {rli}")
     assert f"{fsi}<#555>{pdi}" in summary
-    assert f"{fsi}`abc123`{pdi}" in summary
+    assert summary.endswith(pdi)
 
 
 def test_timezone_and_content_labels() -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.13"
+version = "0.1.14"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Second pass on the schedule-list bidi. The previous `RLM`-forced-RTL approach clumped the Latin id together with the channel mention.

Determined the correct structure empirically by rendering candidates through a browser's Unicode Bidi Algorithm (identical to Discord's Electron renderer): **keep the id plain at the line start, and wrap only the Arabic message after it in an RTL isolate (`U+2067 RLI … U+2069 PDI`)**, with the channel in an `FSI` isolate.

Result:
```
- 57idmgarivwx5cz - # general دعاء اليوم كل يوم الساعة ٨ صباحًا بتوقيت مكة في
```
id at the front, `# general` renders correctly (not reversed), `في #channel` adjacent and correct, independent of the channel name's script.

Gates: ruff + mypy (104 files) + 52 tests green.