### PR TITLE
fix(api): refresh the PocketBase token when a stale session returns 403

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.15"
+version = "0.1.16"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/shared/pocketbase/client.py
+++ b/apps/api/src/shared/pocketbase/client.py
@@ -1,10 +1,15 @@
+import asyncio
 from typing import Any
 
 import httpx
 
 from src.shared.errors.exceptions import UpstreamError
+from src.shared.logging.setup import get_logger
+
+logger = get_logger("api.pocketbase")
 
 _SUPERUSER_AUTH_PATH = "/api/collections/_superusers/auth-with-password"
+_STALE_TOKEN_STATUSES = frozenset({401, 403})
 
 
 class PocketBaseClient:
@@ -16,6 +21,8 @@ class PocketBaseClient:
         self._email = email
         self._password = password
         self._token: str | None = None
+        self._token_version = 0
+        self._auth_lock = asyncio.Lock()
 
     @property
     def has_credentials(self) -> bool:
@@ -23,6 +30,7 @@ class PocketBaseClient:
 
     async def authenticate(self) -> None:
         if not self.has_credentials:
+            logger.warning("pocketbase_credentials_missing writes_will_be_rejected")
             return
         response = await self._send(
             "POST",
@@ -34,6 +42,16 @@ class PocketBaseClient:
         except httpx.HTTPError as exc:
             raise UpstreamError(f"PocketBase authentication failed: {exc}") from exc
         self._token = response.json().get("token")
+        self._token_version += 1
+
+    async def _refresh_token(self, seen_version: int) -> bool:
+        if not self.has_credentials:
+            return False
+        async with self._auth_lock:
+            if self._token_version != seen_version:
+                return True
+            await self.authenticate()
+        return True
 
     async def list_records(
         self, collection: str, params: dict[str, Any] | None = None
@@ -77,14 +95,7 @@ class PocketBaseClient:
 
     async def delete_record(self, collection: str, record_id: str) -> None:
         path = f"/api/collections/{collection}/records/{record_id}"
-        response = await self._send("DELETE", path)
-        if response.status_code == 401 and self.has_credentials:
-            await self.authenticate()
-            response = await self._send("DELETE", path)
-        try:
-            response.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise UpstreamError(f"PocketBase request failed: {exc}") from exc
+        await self._authorized_send("DELETE", path)
 
     async def _request(
         self,
@@ -94,16 +105,29 @@ class PocketBaseClient:
         json: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
+        response = await self._authorized_send(method, path, json=json, params=params)
+        data: dict[str, Any] = response.json()
+        return data
+
+    async def _authorized_send(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        version = self._token_version
         response = await self._send(method, path, json=json, params=params)
-        if response.status_code == 401 and self.has_credentials:
-            await self.authenticate()
+        if response.status_code in _STALE_TOKEN_STATUSES and await self._refresh_token(
+            version
+        ):
             response = await self._send(method, path, json=json, params=params)
         try:
             response.raise_for_status()
         except httpx.HTTPError as exc:
             raise UpstreamError(f"PocketBase request failed: {exc}") from exc
-        data: dict[str, Any] = response.json()
-        return data
+        return response
 
     async def _send(
         self,

--- a/apps/api/tests/test_pocketbase.py
+++ b/apps/api/tests/test_pocketbase.py
@@ -1,0 +1,141 @@
+import asyncio
+from typing import Any, cast
+
+import httpx
+import pytest
+from src.shared.errors.exceptions import UpstreamError
+from src.shared.pocketbase.client import PocketBaseClient
+
+_AUTH_PATH = "/api/collections/_superusers/auth-with-password"
+_RECORDS_PATH = "/api/collections/prayers/records"
+
+
+class FakeTransport:
+    def __init__(self, *, stale_statuses: list[int] | None = None) -> None:
+        self.valid_token: str | None = None
+        self.auth_calls = 0
+        self.write_calls = 0
+        self.stale_statuses = stale_statuses or []
+        self.auth_delay = 0.0
+
+    def _response(self, status_code: int, payload: dict[str, Any]) -> httpx.Response:
+        return httpx.Response(
+            status_code,
+            json=payload,
+            request=httpx.Request("POST", "http://pb.test"),
+        )
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        if url.endswith(_AUTH_PATH):
+            self.auth_calls += 1
+            if self.auth_delay:
+                await asyncio.sleep(self.auth_delay)
+            self.valid_token = f"token-{self.auth_calls}"
+            return self._response(200, {"token": self.valid_token})
+
+        self.write_calls += 1
+        if self.stale_statuses:
+            status = self.stale_statuses.pop(0)
+            return self._response(
+                status, {"message": "Only superusers can perform this action."}
+            )
+        token = (headers or {}).get("Authorization")
+        if token != self.valid_token:
+            return self._response(
+                403, {"message": "Only superusers can perform this action."}
+            )
+        return self._response(200, {"id": "p1", "status": "pending"})
+
+
+def _client(transport: FakeTransport, *, credentials: bool = True) -> PocketBaseClient:
+    return PocketBaseClient(
+        "http://pb.test",
+        cast(httpx.AsyncClient, transport),
+        "admin@ad3oni.com" if credentials else "",
+        "secret" if credentials else "",
+    )
+
+
+@pytest.mark.asyncio
+async def test_expired_token_403_triggers_reauth_and_retry() -> None:
+    transport = FakeTransport(stale_statuses=[403])
+    client = _client(transport)
+    await client.authenticate()
+
+    record = await client.create_record("prayers", {"text": "اللهم ارزقني الصبر"})
+
+    assert record["id"] == "p1"
+    assert transport.auth_calls == 2
+    assert transport.write_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_token_401_still_triggers_reauth() -> None:
+    transport = FakeTransport(stale_statuses=[401])
+    client = _client(transport)
+    await client.authenticate()
+
+    record = await client.create_record("prayers", {"text": "اللهم اشرح لي صدري"})
+
+    assert record["id"] == "p1"
+    assert transport.auth_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_record_also_recovers_from_403() -> None:
+    transport = FakeTransport(stale_statuses=[403])
+    client = _client(transport)
+    await client.authenticate()
+
+    await client.delete_record("prayers", "p1")
+
+    assert transport.auth_calls == 2
+    assert transport.write_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_persistent_403_is_not_retried_forever() -> None:
+    transport = FakeTransport(stale_statuses=[403, 403])
+    client = _client(transport)
+    await client.authenticate()
+
+    with pytest.raises(UpstreamError):
+        await client.create_record("prayers", {"text": "اللهم اغفر لي"})
+
+    assert transport.write_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_does_not_retry() -> None:
+    transport = FakeTransport(stale_statuses=[403])
+    client = _client(transport, credentials=False)
+    await client.authenticate()
+
+    with pytest.raises(UpstreamError):
+        await client.create_record("prayers", {"text": "اللهم ارحمني"})
+
+    assert transport.auth_calls == 0
+    assert transport.write_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stale_writes_reauthenticate_once() -> None:
+    transport = FakeTransport(stale_statuses=[403] * 5)
+    transport.auth_delay = 0.01
+    client = _client(transport)
+    await client.authenticate()
+
+    results = await asyncio.gather(
+        *(client.create_record("prayers", {"text": f"دعاء {index}"}) for index in range(5))
+    )
+
+    assert all(record["id"] == "p1" for record in results)
+    assert transport.auth_calls == 2


### PR DESCRIPTION
## The bug

Submitting a prayer returned:

```json
{"error":{"code":"upstream_error","message":"PocketBase request failed: Client error '403 Forbidden' for url '.../api/collections/prayers/records'"}}
```

## Root cause

The PocketBase superuser token lasts **24 hours**. `PocketBaseClient` authenticates once in `lifespan` and only re-authenticates on **401**.

But PocketBase answers a rule-protected write with **403** `"Only superusers can perform this action."` when the token is stale, not 401. So the retry never fired and every write failed permanently until the container restarted.

Verified against production PocketBase:

| request | result |
|---|---|
| `createRule` on `prayers` | `null` (superusers only) |
| write, no/stale token | `403 Only superusers can perform this action.` |
| read, no/stale token | `200` (listRule/viewRule are public) |
| superuser token lifetime | `24.0 hours` |

That is why submissions worked for 24h after each deploy and then broke, while the site kept rendering prayers fine. The same stale token was also silently blocking ingestion writes (`claim`/`finalize`), the midnight daily-assignment cron, and Discord schedule writes.

## The fix

- Treat **401 and 403** alike as stale-token signals.
- Route `_request` and `delete_record` through one shared `_authorized_send` retry path (the retry logic was duplicated and drifting).
- Guard re-auth with a lock plus a token version so concurrent stale writes trigger **one** re-auth, not one per request.
- Log a warning when credentials are missing, instead of `authenticate()` silently no-opping.

Retry happens at most once; a genuine permission error still surfaces as `UpstreamError`.

## Verification

- 6 new regression tests in `tests/test_pocketbase.py` covering 403 recovery, 401 recovery, delete recovery, persistent-403 not looping, missing-credentials not retrying, and single re-auth under concurrency.
- Full suite: **60 passed**. `ruff` clean. `mypy` clean (97 files).
- End-to-end against production PocketBase with a deliberately poisoned token: create + delete both succeed after automatic re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb