### PR TITLE
feat(web): open the share modal straight from the hero CTA

### DIFF
--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.15"
+version = "0.1.16"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/src/features/landing/components/Hero.tsx
+++ b/apps/web/src/features/landing/components/Hero.tsx
@@ -5,6 +5,7 @@ import { motion, useReducedMotion, type Variants } from "motion/react";
 import { useQuery } from "@tanstack/react-query";
 import { buttonVariants } from "@/shared/ui/button";
 import { randomPrayerQueryOptions } from "@/features/prayers/queries";
+import { ShareButton } from "@/features/share/components/ShareButton";
 import { dailyPrayer } from "../data/prayer";
 import { BracePrayer } from "./BracePrayer";
 
@@ -63,9 +64,9 @@ export const Hero = () => {
           variants={item}
           className="flex flex-col items-center gap-3 sm:flex-row"
         >
-          <a href="#share" className={buttonVariants({ variant: "paper", size: "lg" })}>
+          <ShareButton variant="paper" size="lg">
             شاركنا دعاءك
-          </a>
+          </ShareButton>
           <a
             href="#platforms"
             className={buttonVariants({ variant: "outline", size: "lg", className: "text-paper" })}


### PR DESCRIPTION
## Problem

The hero's **شاركنا دعاءك** button was an `<a href="#share">`, so clicking it scrolled the visitor down to the share section rather than letting them write. They then had to find and press a second button to actually open the input.

## Change

Swapped it for the existing `ShareButton`, which opens the modal via the Zustand store — the same path the nav, community, and share sections already use. No new state, no new component.

```diff
-<a href="#share" className={buttonVariants({ variant: "paper", size: "lg" })}>
+<ShareButton variant="paper" size="lg">
   شاركنا دعاءك
-</a>
+</ShareButton>
```

`ShareButton` applies the identical `buttonVariants({ variant: "paper", size: "lg" })`, so the button looks exactly the same.

## Verification

Typecheck clean, eslint clean. Smoke-tested in a real browser against the dev server:

- Hero CTA now renders as `button`, not a `#share` link.
- Clicking it opens the modal **in place over the hero** — the URL stays at `/`, no scroll.
- Textarea receives focus automatically, counter reads `٠ / ٢٨٠`, submit stays disabled until valid.
- Re-tested the nav entry point to confirm no regression there.

## Also included

`apps/api/uv.lock` is synced to the `0.1.16` version bump from #25, so the lockfile and `pyproject.toml` agree. The api build uses `uv sync --frozen` (which skips the freshness check, unlike `--locked`), so the drift was not breaking the build — but leaving them disagreeing is a trap for the next person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb