### PR TITLE
feat(api): post the daily du'a to X through a saved browser session

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,3 +20,13 @@ DISCORD_PUBLIC_KEY=
 DISCORD_APP_ID=
 DISCORD_BOT_TOKEN=
 DISCORD_GUILD_ID=
+DISCORD_ALERT_CHANNEL_ID=
+
+# X posting via browser automation.
+# X_SESSION_STATE is produced by: uv run python scripts/save_x_session.py
+# It contains live session cookies. Store it in Infisical, never in git.
+X_ENABLED=false
+X_HANDLE=ad3oni_
+X_SESSION_STATE=
+X_HEADLESS=true
+X_DRY_RUN=false

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,1 +1,4 @@
 src/features/seed/candidates.json
+
+# X session cookies, never commit
+x-session.json

--- a/apps/api/Dockerfile.playwright
+++ b/apps/api/Dockerfile.playwright
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/playwright/python:v1.61.0-noble
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
+
+WORKDIR /app
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY pyproject.toml uv.lock ./
+
+RUN uv sync --frozen --no-install-project --no-dev --group playwright
+
+COPY src ./src
+COPY scripts ./scripts
+
+CMD ["python", "scripts/post_daily_to_x.py"]

--- a/apps/api/X_POSTING.md
+++ b/apps/api/X_POSTING.md
@@ -1,0 +1,87 @@
+# Posting the daily du'a to X
+
+This posts through a real browser session rather than the X API.
+
+**Read this first.** Automated posting through the web UI is against X's automation
+rules. The realistic failure mode is suspension of `@ad3oni_`. This is the trade
+that was accepted: the official API costs about $0.45/month at one link-free post
+per day, and cannot get the account suspended.
+
+The feature is inert until `X_ENABLED=true`, so merging it changes nothing.
+
+## One-time setup
+
+### 1. Capture a session
+
+Run locally, not on the server. A browser window opens; log in yourself.
+
+```bash
+cd apps/api
+uv sync --group playwright
+uv run playwright install chromium
+uv run python scripts/save_x_session.py
+```
+
+The script never sees your password. It waits until a logged-in timeline is
+visible, then writes `apps/api/x-session.json` containing only cookies.
+
+### 2. Store the session
+
+`x-session.json` is gitignored and must stay that way. Put its contents in
+`X_SESSION_STATE`, sync to Infisical, then delete the local file.
+
+```bash
+# push to Infisical via the sync-env skill, then:
+rm apps/api/x-session.json
+```
+
+### 3. Configure
+
+| Variable | Purpose |
+|---|---|
+| `X_ENABLED` | Master switch. Leave `false` until you have tested. |
+| `X_SESSION_STATE` | The captured cookies. Bootstraps Redis on first run. |
+| `X_HANDLE` | Used for read-back verification. Default `ad3oni_`. |
+| `X_HEADLESS` | `true` in production. |
+| `X_DRY_RUN` | Logs the post text and exits without posting. |
+| `DISCORD_ALERT_CHANNEL_ID` | Where failures are reported. Strongly recommended. |
+
+### 4. Dry run
+
+```bash
+X_ENABLED=true X_DRY_RUN=true uv run python scripts/post_daily_to_x.py
+```
+
+Confirms prayer selection and formatting without touching X.
+
+## Deploying
+
+Build from `Dockerfile.playwright`, which is separate so the api and worker
+images stay slim. The container runs `scripts/post_daily_to_x.py` once and exits,
+so schedule it as a Coolify Scheduled Task rather than a long-running service.
+
+Suggested schedule: `0 8 * * *` (08:00 Mecca time), matching the Discord default.
+
+## How it behaves
+
+- **Session lives in Redis** at `ad3oni:x:session`, refreshed after every
+  successful post. X rotates cookies, so writing the refreshed state back is what
+  keeps the session alive. `X_SESSION_STATE` is only a bootstrap.
+- **Posts are deduplicated** per Mecca day at `ad3oni:x:posted:<date>`, so a retry
+  or double-fire cannot post twice.
+- **Every post is verified**, first by waiting for the confirmation toast, then by
+  reading the profile timeline back and matching the text. An unverified post is
+  reported as a failure rather than silently assumed to have worked.
+- **Du'as longer than 280 characters are skipped**, not truncated, and an alert is
+  sent. About 2 of 83 current prayers are affected. Note X counts each haraka as a
+  character, so vocalised text is much longer than it looks.
+- **The bot never logs in.** If the session expires it raises, alerts, and stops.
+  Re-run step 1.
+
+## When it breaks
+
+It will. Cookies expire, and X changes its UI without notice. Failures alert to
+Discord if `DISCORD_ALERT_CHANNEL_ID` is set. If posts stop, check that channel
+first, then re-capture the session.
+
+The selectors most likely to break are in `src/features/x/keys.py`.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.16"
+version = "0.2.0"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",
@@ -16,6 +16,9 @@ dependencies = [
 ]
 
 [dependency-groups]
+playwright = [
+    "playwright==1.61.0",
+]
 dev = [
     "ruff==0.8.6",
     "mypy==1.14.1",

--- a/apps/api/scripts/post_daily_to_x.py
+++ b/apps/api/scripts/post_daily_to_x.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import httpx
+from src.features.x.service import post_daily_to_x
+from src.shared.ai.client import create_ai_client
+from src.shared.config.settings import get_settings
+from src.shared.logging.setup import configure_logging, get_logger
+from src.shared.pocketbase.client import PocketBaseClient
+from src.shared.queue.context import WorkerContext
+from src.shared.queue.pool import create_arq_pool
+
+logger = get_logger("api.x.cli")
+
+
+async def main() -> None:
+    settings = get_settings()
+    configure_logging(settings.log_level)
+
+    redis = await create_arq_pool(settings)
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        pocketbase = PocketBaseClient(
+            settings.pocketbase_url,
+            http,
+            settings.pocketbase_admin_email,
+            settings.pocketbase_admin_password,
+        )
+        await pocketbase.authenticate()
+        context = WorkerContext(settings, pocketbase, create_ai_client(settings), http)
+        try:
+            posted = await post_daily_to_x(context, redis)
+        finally:
+            await redis.aclose()
+
+    raise SystemExit(0 if posted else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/api/scripts/save_x_session.py
+++ b/apps/api/scripts/save_x_session.py
@@ -1,0 +1,58 @@
+import asyncio
+import json
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+from src.features.x.keys import ACCOUNT_SWITCHER, HOME_URL
+
+_OUTPUT = Path(__file__).resolve().parent.parent / "x-session.json"
+_LOGIN_TIMEOUT_MS = 5 * 60 * 1000
+
+_INSTRUCTIONS = """
+A browser window will open on x.com.
+
+  1. Log in there yourself, exactly as you normally would.
+  2. Complete any 2FA or captcha challenge.
+  3. Wait until your home timeline is visible.
+
+This script never sees or stores your password. It waits for a valid session
+and then saves only the resulting cookies.
+
+Do not commit the output file. Push it to Infisical as X_SESSION_STATE instead.
+"""
+
+
+async def main() -> None:
+    print(_INSTRUCTIONS)
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(headless=False)
+        context = await browser.new_context(
+            locale="ar",
+            timezone_id="Asia/Riyadh",
+            viewport={"width": 1280, "height": 900},
+        )
+        page = await context.new_page()
+        await page.goto(HOME_URL)
+
+        print("waiting for a logged-in session (up to 5 minutes)...")
+        try:
+            await page.wait_for_selector(ACCOUNT_SWITCHER, timeout=_LOGIN_TIMEOUT_MS)
+        except Exception:
+            print("timed out before a session appeared; nothing was saved")
+            await browser.close()
+            raise SystemExit(1) from None
+
+        state = await context.storage_state()
+        await browser.close()
+
+    _OUTPUT.write_text(json.dumps(state), encoding="utf-8")
+    cookies = state.get("cookies", [])
+    print(f"\nsaved {len(cookies)} cookies to {_OUTPUT}")
+    print("\nNext:")
+    print(f"  1. Set X_SESSION_STATE to the contents of {_OUTPUT.name}")
+    print("  2. Sync it to Infisical, then delete the local file")
+    print(f"  3. rm {_OUTPUT}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/api/src/features/x/keys.py
+++ b/apps/api/src/features/x/keys.py
@@ -1,0 +1,18 @@
+X_SESSION = "ad3oni:x:session"
+X_LAST_POST = "ad3oni:x:last_post"
+
+HOME_URL = "https://x.com/home"
+COMPOSE_URL = "https://x.com/compose/post"
+PROFILE_URL = "https://x.com/{handle}"
+
+EDITOR = '[data-testid="tweetTextarea_0"]'
+SUBMIT = '[data-testid="tweetButton"]'
+ACCOUNT_SWITCHER = '[data-testid="SideNav_AccountSwitcher_Button"]'
+TOAST = '[data-testid="toast"]'
+TWEET_TEXT = '[data-testid="tweetText"]'
+
+MAX_POST_LENGTH = 280
+
+
+def posted_key(day: str) -> str:
+    return f"ad3oni:x:posted:{day}"

--- a/apps/api/src/features/x/poster.py
+++ b/apps/api/src/features/x/poster.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Any, cast
+
+from playwright.async_api import Page, async_playwright
+from playwright.async_api import TimeoutError as PlaywrightTimeout
+from src.features.x.keys import (
+    ACCOUNT_SWITCHER,
+    COMPOSE_URL,
+    EDITOR,
+    HOME_URL,
+    PROFILE_URL,
+    SUBMIT,
+    TOAST,
+    TWEET_TEXT,
+)
+from src.shared.logging.setup import get_logger
+
+logger = get_logger("api.x.poster")
+
+_LAUNCH_ARGS = [
+    "--disable-blink-features=AutomationControlled",
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+]
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+)
+_VERIFY_SLICE = 40
+
+
+class SessionExpiredError(RuntimeError):
+    pass
+
+
+class PostVerificationError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class PostResult:
+    verified: bool
+    storage_state: dict[str, Any]
+
+
+async def _assert_logged_in(page: Page, timeout_ms: int) -> None:
+    try:
+        await page.wait_for_selector(ACCOUNT_SWITCHER, timeout=timeout_ms)
+    except PlaywrightTimeout as exc:
+        raise SessionExpiredError(
+            "X session is no longer valid. Re-run scripts/save_x_session.py."
+        ) from exc
+
+
+async def _compose(page: Page, text: str, timeout_ms: int) -> None:
+    await page.goto(COMPOSE_URL, wait_until="domcontentloaded")
+    editor = page.locator(EDITOR)
+    await editor.wait_for(state="visible", timeout=timeout_ms)
+    await editor.click()
+    await page.keyboard.type(text, delay=12)
+
+    submit = page.locator(SUBMIT)
+    await submit.wait_for(state="visible", timeout=timeout_ms)
+    if await submit.is_disabled():
+        raise PostVerificationError("Compose button stayed disabled; text may be too long.")
+    await submit.click()
+
+
+async def _confirm_via_toast(page: Page, timeout_ms: int) -> bool:
+    try:
+        await page.wait_for_selector(TOAST, timeout=timeout_ms)
+    except PlaywrightTimeout:
+        return False
+    return True
+
+
+async def _confirm_via_profile(page: Page, handle: str, text: str, timeout_ms: int) -> bool:
+    await page.goto(PROFILE_URL.format(handle=handle), wait_until="domcontentloaded")
+    try:
+        await page.wait_for_selector(TWEET_TEXT, timeout=timeout_ms)
+    except PlaywrightTimeout:
+        return False
+    recent = await page.locator(TWEET_TEXT).first.inner_text()
+    needle = text[:_VERIFY_SLICE].strip()
+    return needle in recent
+
+
+async def publish(
+    text: str,
+    *,
+    storage_state: dict[str, Any],
+    handle: str,
+    headless: bool,
+    timeout_ms: int,
+) -> PostResult:
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(headless=headless, args=_LAUNCH_ARGS)
+        try:
+            context = await browser.new_context(
+                storage_state=storage_state,  # type: ignore[arg-type]
+                locale="ar",
+                timezone_id="Asia/Riyadh",
+                user_agent=_USER_AGENT,
+                viewport={"width": 1280, "height": 900},
+            )
+            page = await context.new_page()
+
+            await page.goto(HOME_URL, wait_until="domcontentloaded")
+            await _assert_logged_in(page, timeout_ms)
+
+            await _compose(page, text, timeout_ms)
+
+            verified = await _confirm_via_toast(page, timeout_ms // 3)
+            if not verified:
+                logger.info("x_toast_missing falling_back_to_profile_readback")
+                verified = await _confirm_via_profile(page, handle, text, timeout_ms)
+
+            refreshed = cast("dict[str, Any]", await context.storage_state())
+            await context.close()
+            return PostResult(verified=verified, storage_state=refreshed)
+        finally:
+            await browser.close()

--- a/apps/api/src/features/x/service.py
+++ b/apps/api/src/features/x/service.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from arq import ArqRedis
+from src.features.daily.keys import MECCA_TIMEZONE
+from src.features.daily.service import DailyService
+from src.features.discord.embeds import info_embed
+from src.features.discord.rest import DiscordRest
+from src.features.prayers.schema import Prayer
+from src.features.x.keys import MAX_POST_LENGTH, X_LAST_POST, posted_key
+from src.features.x.poster import SessionExpiredError, publish
+from src.features.x.session import load_session, save_session
+from src.shared.errors.exceptions import NotFoundError
+from src.shared.logging.setup import get_logger
+from src.shared.queue.context import WorkerContext
+
+logger = get_logger("api.x.service")
+
+_POSTED_TTL_SECONDS = 60 * 60 * 48
+
+
+def compose_post(prayer: Prayer) -> str | None:
+    text = prayer.text.strip()
+    if len(text) > MAX_POST_LENGTH:
+        return None
+    if prayer.source:
+        with_source = f"{text}\n\n{prayer.source.strip()}"
+        if len(with_source) <= MAX_POST_LENGTH:
+            return with_source
+    return text
+
+
+def _today() -> str:
+    return datetime.now(ZoneInfo(MECCA_TIMEZONE)).date().isoformat()
+
+
+async def _alert(context: WorkerContext, message: str) -> None:
+    channel = context.settings.discord_alert_channel_id
+    token = context.settings.discord_bot_token
+    if not channel or not token:
+        return
+    rest = DiscordRest(context.http, token)
+    await rest.post_message(channel, info_embed(f"‏X: {message}"))
+
+
+async def post_daily_to_x(context: WorkerContext, redis: ArqRedis) -> bool:
+    settings = context.settings
+    if not settings.x_enabled:
+        logger.info("x_disabled skipping")
+        return False
+
+    day = _today()
+    if await redis.get(posted_key(day)) is not None:
+        logger.info("x_already_posted day=%s", day)
+        return False
+
+    try:
+        prayer = await DailyService(context.pocketbase, redis).get_daily()
+    except NotFoundError:
+        logger.warning("x_no_prayer_available")
+        return False
+
+    text = compose_post(prayer)
+    if text is None:
+        logger.warning("x_prayer_too_long id=%s len=%d", prayer.id, len(prayer.text))
+        await _alert(
+            context,
+            f"دعاء اليوم أطول من {MAX_POST_LENGTH} حرفًا، فلم يُنشر. المعرّف: {prayer.id}",
+        )
+        return False
+
+    if settings.x_dry_run:
+        logger.info("x_dry_run text=%r", text)
+        return False
+
+    state = await load_session(redis, settings.x_session_state)
+    if state is None:
+        logger.error("x_no_session")
+        await _alert(context, "لا توجد جلسة محفوظة. شغّل scripts/save_x_session.py")
+        return False
+
+    try:
+        result = await publish(
+            text,
+            storage_state=state,
+            handle=settings.x_handle,
+            headless=settings.x_headless,
+            timeout_ms=settings.x_post_timeout_ms,
+        )
+    except SessionExpiredError as error:
+        logger.error("x_session_expired")
+        await _alert(context, f"انتهت صلاحية الجلسة: {error}")
+        return False
+    except Exception as error:
+        logger.exception("x_post_failed")
+        await _alert(context, f"فشل النشر: {type(error).__name__}: {error}")
+        return False
+
+    await save_session(redis, result.storage_state)
+
+    if not result.verified:
+        logger.error("x_post_unverified id=%s", prayer.id)
+        await _alert(context, "أُرسل المنشور لكن تعذّر التأكد من ظهوره. راجع الحساب.")
+        return False
+
+    await redis.set(posted_key(day), prayer.id, ex=_POSTED_TTL_SECONDS)
+    await redis.set(X_LAST_POST, f"{day}:{prayer.id}")
+    logger.info("x_posted day=%s prayer=%s", day, prayer.id)
+    return True

--- a/apps/api/src/features/x/session.py
+++ b/apps/api/src/features/x/session.py
@@ -1,0 +1,51 @@
+import json
+from typing import Any
+
+from arq import ArqRedis
+from src.features.x.keys import X_SESSION
+from src.shared.logging.setup import get_logger
+
+logger = get_logger("api.x.session")
+
+
+def _decode(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def parse_state(raw: str) -> dict[str, Any] | None:
+    try:
+        state: dict[str, Any] = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(state.get("cookies"), list):
+        return None
+    return state
+
+
+async def load_session(redis: ArqRedis, bootstrap: str) -> dict[str, Any] | None:
+    stored = _decode(await redis.get(X_SESSION))
+    if stored:
+        state = parse_state(stored)
+        if state is not None:
+            return state
+        logger.warning("x_session_in_redis_unparseable falling_back_to_env")
+
+    if not bootstrap:
+        return None
+
+    state = parse_state(bootstrap)
+    if state is None:
+        logger.error("x_session_env_unparseable")
+        return None
+
+    await save_session(redis, state)
+    logger.info("x_session_bootstrapped_from_env")
+    return state
+
+
+async def save_session(redis: ArqRedis, state: dict[str, Any]) -> None:
+    await redis.set(X_SESSION, json.dumps(state))

--- a/apps/api/src/shared/config/settings.py
+++ b/apps/api/src/shared/config/settings.py
@@ -58,6 +58,14 @@ class Settings(BaseSettings):
     discord_bot_token: str = ""
     discord_guild_id: str = ""
     discord_schedule_limit: int = 15
+    discord_alert_channel_id: str = ""
+
+    x_enabled: bool = False
+    x_handle: str = "ad3oni_"
+    x_session_state: str = ""
+    x_post_timeout_ms: int = 45_000
+    x_headless: bool = True
+    x_dry_run: bool = False
 
     @property
     def is_production(self) -> bool:

--- a/apps/api/tests/test_x.py
+++ b/apps/api/tests/test_x.py
@@ -1,0 +1,111 @@
+import json
+from typing import Any, cast
+
+import pytest
+from arq import ArqRedis
+from src.features.prayers.schema import Prayer
+from src.features.x.keys import MAX_POST_LENGTH, X_SESSION
+from src.features.x.service import compose_post
+from src.features.x.session import load_session, parse_state, save_session
+
+
+def _prayer(text: str, source: str | None = None) -> Prayer:
+    return Prayer(
+        id="p1",
+        text=text,
+        status="confirmed",
+        source=source,
+        created="2026-07-19 00:00:00.000Z",
+        updated="2026-07-19 00:00:00.000Z",
+    )
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    async def get(self, key: str) -> bytes | None:
+        value = self.values.get(key)
+        return value.encode() if value is not None else None
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.values[key] = value
+
+
+def test_compose_appends_source_when_it_fits() -> None:
+    post = compose_post(_prayer("اللهم اغفر لي", "صحيح مسلم"))
+    assert post == "اللهم اغفر لي\n\nصحيح مسلم"
+
+
+def test_compose_drops_source_when_it_would_overflow() -> None:
+    text = "ا" * (MAX_POST_LENGTH - 3)
+    post = compose_post(_prayer(text, "صحيح البخاري"))
+    assert post == text
+    assert len(post or "") <= MAX_POST_LENGTH
+
+
+def test_compose_returns_none_when_prayer_itself_is_too_long() -> None:
+    assert compose_post(_prayer("ا" * (MAX_POST_LENGTH + 1))) is None
+
+
+def test_compose_accepts_prayer_at_exactly_the_limit() -> None:
+    text = "ا" * MAX_POST_LENGTH
+    assert compose_post(_prayer(text)) == text
+
+
+def test_parse_state_rejects_garbage() -> None:
+    assert parse_state("not json") is None
+    assert parse_state('{"no":"cookies"}') is None
+    assert parse_state('{"cookies": []}') == {"cookies": []}
+
+
+@pytest.mark.asyncio
+async def test_session_bootstraps_from_env_then_persists() -> None:
+    redis = FakeRedis()
+    bootstrap = json.dumps({"cookies": [{"name": "auth_token"}]})
+
+    state = await load_session(cast(ArqRedis, redis), bootstrap)
+
+    assert state is not None
+    assert state["cookies"][0]["name"] == "auth_token"
+    assert X_SESSION in redis.values
+
+
+@pytest.mark.asyncio
+async def test_session_prefers_redis_over_env() -> None:
+    redis = FakeRedis()
+    redis.values[X_SESSION] = json.dumps({"cookies": [{"name": "fresh"}]})
+    stale = json.dumps({"cookies": [{"name": "stale"}]})
+
+    state = await load_session(cast(ArqRedis, redis), stale)
+
+    assert state is not None
+    assert state["cookies"][0]["name"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_session_falls_back_to_env_when_redis_corrupt() -> None:
+    redis = FakeRedis()
+    redis.values[X_SESSION] = "corrupted"
+    bootstrap = json.dumps({"cookies": [{"name": "auth_token"}]})
+
+    state = await load_session(cast(ArqRedis, redis), bootstrap)
+
+    assert state is not None
+    assert state["cookies"][0]["name"] == "auth_token"
+
+
+@pytest.mark.asyncio
+async def test_no_session_anywhere_returns_none() -> None:
+    assert await load_session(cast(ArqRedis, FakeRedis()), "") is None
+
+
+@pytest.mark.asyncio
+async def test_save_session_roundtrips() -> None:
+    redis = FakeRedis()
+    state: dict[str, Any] = {"cookies": [{"name": "ct0", "value": "abc"}]}
+
+    await save_session(cast(ArqRedis, redis), state)
+    loaded = await load_session(cast(ArqRedis, redis), "")
+
+    assert loaded == state

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -57,6 +57,9 @@ dev = [
     { name = "ruff" },
     { name = "types-croniter" },
 ]
+playwright = [
+    { name = "playwright" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -80,6 +83,7 @@ dev = [
     { name = "ruff", specifier = "==0.8.6" },
     { name = "types-croniter", specifier = ">=6.2.2.20260518" },
 ]
+playwright = [{ name = "playwright", specifier = "==1.61.0" }]
 
 [[package]]
 name = "arq"
@@ -204,6 +208,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
 ]
 
 [[package]]
@@ -419,6 +470,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +573,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/41/19b62b99e7530cfa1d6ccd16199afd9289a12929bef1a03aa4382b22e683/pydantic_settings-2.7.0.tar.gz", hash = "sha256:ac4bfd4a36831a48dbf8b2d9325425b549a0a6f18cea118436d728eb4f1c4d66", size = 79743, upload-time = "2024-12-13T09:41:11.477Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/00/57b4540deb5c3a39ba689bb519a4e03124b24ab8589e618be4aac2c769bd/pydantic_settings-2.7.0-py3-none-any.whl", hash = "sha256:e00c05d5fa6cbbb227c84bd7487c5c1065084119b750df7c8c1a554aed236eb5", size = 29549, upload-time = "2024-12-13T09:41:09.54Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Posts the daily du'a to [@ad3oni_](https://twitter.com/ad3oni_) by driving a real browser session, avoiding the X API's pay-per-use cost.

**Inert until `X_ENABLED=true`.** Merging changes nothing.

## The trade-off, stated plainly

This breaches X's automation rules, and the realistic failure mode is suspension of `@ad3oni_`. The official API costs about **$0.45/month** at one link-free post per day and carries no such risk. That trade was made deliberately and is documented in `X_POSTING.md` so it isn't forgotten in six months.

## Design

**The bot never logs in.** `scripts/save_x_session.py` opens a browser, you sign in by hand, and only the resulting cookies are saved. No password exists anywhere in the codebase, and it keeps working with 2FA enabled. Scripted logins are also the fastest way to get flagged, so avoiding them reduces the very risk we're worried about.

**The session is kept alive.** It lives in Redis and is written back after every post. X rotates cookies, so persisting the refreshed state is the difference between a session that lasts and one that dies quietly after a few days. `X_SESSION_STATE` is only a bootstrap.

**Posts are verified, not assumed.** First the confirmation toast, then a fallback that reads the profile timeline back and matches the text. An unverified post is reported as a *failure* — for a daily reminder, silently stopping is the worst outcome, so the design refuses to guess.

**Other guards:** deduplicated per Mecca day so a retry can't double-post; du'as over 280 characters are skipped rather than truncated (cutting scripture mid-sentence isn't acceptable — and X counts each haraka, so vocalised text is far longer than it looks: 2 of 83 prayers are affected); failures alert to Discord via the existing bot.

**Isolation:** Playwright sits in its own dependency group and its own `Dockerfile.playwright`, so the api and worker images stay slim. The container runs once and exits, suiting a scheduled task.

## Verification

- 10 new tests; full suite **70 passed**. `ruff` and `mypy` clean (102 files).
- Exercised the **real browser path**: launches Chromium, loads x.com with an invalid session, and raises a clean `SessionExpiredError` instead of hanging. Everything but the authenticated post is proven; that part needs a captured session.
- Confirmed `x-session.json` is gitignored and that no session file is staged.

## Not done here

The Coolify scheduled task is deliberately not created, and `X_ENABLED` stays `false`. Activating it starts posting to a live public account, which should be a human decision after a dry run. Steps are in `X_POSTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb