### PR TITLE
feat(api): run the X poster as a long-running arq worker

### DIFF
--- a/apps/api/Dockerfile.playwright
+++ b/apps/api/Dockerfile.playwright
@@ -17,4 +17,4 @@ RUN uv sync --frozen --no-install-project --no-dev --group playwright
 COPY src ./src
 COPY scripts ./scripts
 
-CMD ["python", "scripts/post_daily_to_x.py"]
+CMD ["sh", "-c", "if [ \"$PROCESS\" = \"once\" ]; then exec python scripts/post_daily_to_x.py; else exec arq src.x_worker.WorkerSettings; fi"]

--- a/apps/api/X_POSTING.md
+++ b/apps/api/X_POSTING.md
@@ -19,7 +19,7 @@ Run locally, not on the server. A browser window opens; log in yourself.
 cd apps/api
 uv sync --group playwright
 uv run playwright install chromium
-uv run python scripts/save_x_session.py
+uv run python -m scripts.save_x_session
 ```
 
 The script never sees your password. It waits until a logged-in timeline is
@@ -49,7 +49,7 @@ rm apps/api/x-session.json
 ### 4. Dry run
 
 ```bash
-X_ENABLED=true X_DRY_RUN=true uv run python scripts/post_daily_to_x.py
+X_ENABLED=true X_DRY_RUN=true uv run python -m scripts.post_daily_to_x
 ```
 
 Confirms prayer selection and formatting without touching X.

--- a/apps/api/src/features/x/poster.py
+++ b/apps/api/src/features/x/poster.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from playwright.async_api import Page, async_playwright
 from playwright.async_api import TimeoutError as PlaywrightTimeout
+
 from src.features.x.keys import (
     ACCOUNT_SWITCHER,
     COMPOSE_URL,

--- a/apps/api/src/features/x/service.py
+++ b/apps/api/src/features/x/service.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from arq import ArqRedis
+
 from src.features.daily.keys import MECCA_TIMEZONE
 from src.features.daily.service import DailyService
 from src.features.discord.embeds import info_embed

--- a/apps/api/src/features/x/session.py
+++ b/apps/api/src/features/x/session.py
@@ -2,6 +2,7 @@ import json
 from typing import Any
 
 from arq import ArqRedis
+
 from src.features.x.keys import X_SESSION
 from src.shared.logging.setup import get_logger
 

--- a/apps/api/src/x_worker.py
+++ b/apps/api/src/x_worker.py
@@ -1,0 +1,67 @@
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+from arq import ArqRedis, cron
+
+from src.features.daily.keys import MECCA_TIMEZONE
+from src.features.x.service import post_daily_to_x
+from src.shared.ai.client import create_ai_client
+from src.shared.config.settings import get_settings
+from src.shared.logging.setup import configure_logging, get_logger
+from src.shared.pocketbase.client import PocketBaseClient
+from src.shared.queue.context import (
+    WorkerContext,
+    get_worker_context,
+    set_worker_context,
+)
+from src.shared.queue.pool import redis_settings_from
+
+logger = get_logger("api.x.worker")
+_settings = get_settings()
+
+
+async def startup(ctx: dict[Any, Any]) -> None:
+    configure_logging(_settings.log_level)
+    settings = get_settings()
+    http = httpx.AsyncClient(timeout=30.0)
+    pocketbase = PocketBaseClient(
+        settings.pocketbase_url,
+        http,
+        settings.pocketbase_admin_email,
+        settings.pocketbase_admin_password,
+    )
+    await pocketbase.authenticate()
+    ai = create_ai_client(settings)
+    set_worker_context(ctx, WorkerContext(settings, pocketbase, ai, http))
+    logger.info(
+        "x_worker_startup enabled=%s dry_run=%s",
+        settings.x_enabled,
+        settings.x_dry_run,
+    )
+
+
+async def shutdown(ctx: dict[Any, Any]) -> None:
+    context = get_worker_context(ctx)
+    await context.http.aclose()
+    logger.info("x_worker_shutdown")
+
+
+async def post_daily(ctx: dict[Any, Any]) -> None:
+    context = get_worker_context(ctx)
+    redis: ArqRedis = ctx["redis"]
+    try:
+        await post_daily_to_x(context, redis)
+    except Exception:
+        logger.exception("x_daily_post_crashed")
+
+
+class WorkerSettings:
+    functions: list[Any] = []
+    cron_jobs = [cron(post_daily, hour=8, minute=0, run_at_startup=False)]
+    timezone = ZoneInfo(MECCA_TIMEZONE)
+    on_startup = startup
+    on_shutdown = shutdown
+    redis_settings = redis_settings_from(_settings)
+    max_jobs = 1
+    job_timeout = 300

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.1.16"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Follow-up to #28.

The one-shot script didn't fit Coolify, which runs scheduled commands *inside a running container*. This adds `src/x_worker.py` — an arq worker holding a single 08:00 Mecca cron, mirroring the shape of the existing worker — so it deploys as an ordinary long-running service. The one-shot path stays available behind `PROCESS=once` for dry runs and manual triggers.

Also fixes the documented invocation: this is a virtual uv project, so `python scripts/foo.py` leaves `src/` off `sys.path` and fails with `ModuleNotFoundError: No module named 'src'`. `python -m scripts.foo` works. The container already sets `PYTHONPATH=/app`, so only local usage was affected.

**Verified:** dry run against production PocketBase reads the daily prayer and composes the post correctly. `ruff`, `mypy` (104 files) and 70 tests all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb