### PR TITLE
chore(api): add a healthcheck to the X worker

### DIFF
--- a/apps/api/Dockerfile.playwright
+++ b/apps/api/Dockerfile.playwright
@@ -17,4 +17,7 @@ RUN uv sync --frozen --no-install-project --no-dev --group playwright
 COPY src ./src
 COPY scripts ./scripts
 
+HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
+    CMD test "$PROCESS" = "once" || pgrep -f "arq src.x_worker" > /dev/null || exit 1
+
 CMD ["sh", "-c", "if [ \"$PROCESS\" = \"once\" ]; then exec python scripts/post_daily_to_x.py; else exec arq src.x_worker.WorkerSettings; fi"]


### PR DESCRIPTION
Without a healthcheck the container reported `running:unknown` in Coolify, so an arq crash would not have surfaced anywhere.

Checks that the arq process is alive, and short-circuits for `PROCESS=once`, which is a one-shot run expected to exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb