### PR TITLE
fix(api): give the X worker its own arq queue

### DIFF
--- a/apps/api/src/x_worker.py
+++ b/apps/api/src/x_worker.py
@@ -57,6 +57,7 @@ async def post_daily(ctx: dict[Any, Any]) -> None:
 
 
 class WorkerSettings:
+    queue_name = "ad3oni:x:queue"
     functions: list[Any] = []
     cron_jobs = [cron(post_daily, hour=8, minute=0, run_at_startup=False)]
     timezone = ZoneInfo(MECCA_TIMEZONE)


### PR DESCRIPTION
## The bug

The new X worker inherited arq's default queue name (`arq:queue`), the same one the main worker uses. Both workers therefore competed for the same jobs. Caught in production logs within a minute of deploying:

```
WARNING arq.worker job cron:dispatch_schedules:1784503140123,
        function 'cron:dispatch_schedules' not found
```

The X worker dequeued the main worker's cron job, found no matching function, and **dropped it**.

## Impact

Discord schedule dispatches were being silently swallowed roughly half the time, depending on which worker grabbed the job first. `process_prayer` ingestion jobs were exposed to the same race, which would have left submissions stuck in `processing` forever.

Checked production: **0 prayers in `processing`, 0 in `pending`** — nothing was lost. The window was about three minutes and cost only a few `dispatch_schedules` ticks.

## Fix

`queue_name = "ad3oni:x:queue"` on the X worker's settings, so each worker only ever sees its own jobs. Verified the two names differ at runtime rather than assuming it.

`ruff`, `mypy` (104 files) and 70 tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb