### PR TITLE
fix(api): stop transient AI failures from stranding prayers in processing

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/ingestion/agents/diacritize.py
+++ b/apps/api/src/features/ingestion/agents/diacritize.py
@@ -7,35 +7,43 @@ from src.features.ingestion.prompts import (
 from src.features.ingestion.schema import DiacritizationResult
 from src.shared.ai.structured import complete_json
 from src.shared.arabic.normalize import harakat_preserves_wording
+from src.shared.errors.exceptions import UpstreamError
 from src.shared.logging.setup import get_logger
 from src.shared.queue.context import WorkerContext
 
 logger = get_logger("api.ingestion")
 
 
-async def _add_harakat(context: WorkerContext, corrected: str) -> str:
-    result = await complete_json(
-        context.ai,
-        context.settings.ai_model,
-        diacritization_system(context.settings.diacritization_mode),
-        diacritization_user(corrected),
-        DiacritizationResult,
-        reasoning_effort=context.settings.diacritization_effort,
-    )
+async def _add_harakat(context: WorkerContext, corrected: str) -> str | None:
+    try:
+        result = await complete_json(
+            context.ai,
+            context.settings.ai_model,
+            diacritization_system(context.settings.diacritization_mode),
+            diacritization_user(corrected),
+            DiacritizationResult,
+            reasoning_effort=context.settings.diacritization_effort,
+        )
+    except UpstreamError:
+        logger.info("diacritization_ai_unavailable")
+        return None
     return result.diacritized_text.strip()
 
 
 async def _verify_harakat(
     context: WorkerContext, corrected: str, diacritized: str
 ) -> str:
-    result = await complete_json(
-        context.ai,
-        context.settings.ai_model,
-        DIACRITIZATION_VERIFY_SYSTEM,
-        diacritization_verify_user(corrected, diacritized),
-        DiacritizationResult,
-        reasoning_effort=context.settings.diacritization_effort,
-    )
+    try:
+        result = await complete_json(
+            context.ai,
+            context.settings.ai_model,
+            DIACRITIZATION_VERIFY_SYSTEM,
+            diacritization_verify_user(corrected, diacritized),
+            DiacritizationResult,
+            reasoning_effort=context.settings.diacritization_effort,
+        )
+    except UpstreamError:
+        return diacritized
     candidate = result.diacritized_text.strip()
     if candidate and harakat_preserves_wording(corrected, candidate):
         return candidate

--- a/apps/api/src/features/ingestion/reaper.py
+++ b/apps/api/src/features/ingestion/reaper.py
@@ -1,0 +1,85 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from arq import ArqRedis
+
+from src.features.ingestion.finalize import finalize_failed
+from src.shared.logging.setup import get_logger
+from src.shared.queue.context import WorkerContext
+from src.shared.queue.pool import enqueue_process_prayer
+
+logger = get_logger("api.ingestion.reaper")
+
+STALE_MINUTES = 5
+GIVE_UP_MINUTES = 6 * 60
+_PAGE_SIZE = 200
+_STUCK_FILTER = '(status = "pending" || status = "processing")'
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    text = value.strip().replace(" ", "T")
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+async def _collect_stuck(context: WorkerContext) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = await context.pocketbase.list_records(
+            "prayers",
+            {
+                "filter": _STUCK_FILTER,
+                "page": page,
+                "perPage": _PAGE_SIZE,
+                "skipTotal": True,
+                "sort": "created",
+                "fields": "id,status,created,updated",
+            },
+        )
+        items = data.get("items", [])
+        records.extend(items)
+        if len(items) < _PAGE_SIZE:
+            return records
+        page += 1
+
+
+async def reap_stuck_prayers(context: WorkerContext, redis: ArqRedis) -> None:
+    now = datetime.now(tz=UTC)
+    stuck = await _collect_stuck(context)
+
+    requeued = 0
+    failed = 0
+    for record in stuck:
+        stamp = _parse_timestamp(record.get("updated") or record.get("created") or "")
+        if stamp is None:
+            continue
+        age_minutes = (now - stamp).total_seconds() / 60
+        if age_minutes < STALE_MINUTES:
+            continue
+
+        prayer_id = record["id"]
+        if age_minutes >= GIVE_UP_MINUTES:
+            await finalize_failed(context, prayer_id)
+            logger.warning(
+                "prayer_reaped_failed id=%s age_min=%.0f", prayer_id, age_minutes
+            )
+            failed += 1
+            continue
+
+        await enqueue_process_prayer(redis, prayer_id)
+        logger.info(
+            "prayer_reaped_requeued id=%s status=%s age_min=%.0f",
+            prayer_id,
+            record.get("status"),
+            age_minutes,
+        )
+        requeued += 1
+
+    if requeued or failed:
+        logger.info("reaper_done requeued=%d failed=%d", requeued, failed)

--- a/apps/api/src/shared/queue/settings.py
+++ b/apps/api/src/shared/queue/settings.py
@@ -9,6 +9,7 @@ from src.features.daily.selection import assign_daily_prayer
 from src.features.discord.scheduler import run_due_schedules
 from src.features.ingestion.finalize import finalize_failed
 from src.features.ingestion.pipeline import run_pipeline
+from src.features.ingestion.reaper import reap_stuck_prayers
 from src.shared.ai.client import create_ai_client
 from src.shared.config.settings import get_settings
 from src.shared.logging.setup import configure_logging, get_logger
@@ -78,11 +79,21 @@ async def dispatch_schedules(ctx: dict[Any, Any]) -> None:
         logger.exception("discord_schedule_dispatch_failed")
 
 
+async def reap_prayers(ctx: dict[Any, Any]) -> None:
+    context = get_worker_context(ctx)
+    redis: ArqRedis = ctx["redis"]
+    try:
+        await reap_stuck_prayers(context, redis)
+    except Exception:
+        logger.exception("prayer_reaper_failed")
+
+
 class WorkerSettings:
     functions = [process_prayer]
     cron_jobs = [
         cron(assign_daily, hour=0, minute=0, run_at_startup=False),
         cron(dispatch_schedules, minute=set(range(60)), second=0),
+        cron(reap_prayers, minute={0, 10, 20, 30, 40, 50}, second=15),
     ]
     timezone = ZoneInfo(MECCA_TIMEZONE)
     on_startup = startup

--- a/apps/api/tests/test_diacritize.py
+++ b/apps/api/tests/test_diacritize.py
@@ -1,0 +1,58 @@
+from typing import Any, cast
+
+import pytest
+from src.features.ingestion import agents
+from src.features.ingestion.agents.diacritize import diacritize
+from src.features.ingestion.schema import DiacritizationResult
+from src.shared.config.settings import Settings
+from src.shared.errors.exceptions import UpstreamError
+from src.shared.queue.context import WorkerContext
+
+_SOURCE = "اللهم اغفر لي وارحمني"
+_VOCALIZED = "اللَّهُمَّ اغْفِرْ لِي وَارْحَمْنِي"
+
+
+def _context() -> WorkerContext:
+    settings = Settings(ai_model="test-model", diacritization_verify_enabled=False)
+    return WorkerContext(
+        settings=settings,
+        pocketbase=cast(Any, None),
+        ai=cast(Any, None),
+        http=cast(Any, None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_diacritize_falls_back_to_plain_when_ai_errors(monkeypatch: Any) -> None:
+    async def boom(*args: Any, **kwargs: Any) -> DiacritizationResult:
+        raise UpstreamError("ai_structured_output_failed:DiacritizationResult")
+
+    monkeypatch.setattr(agents.diacritize, "complete_json", boom)
+
+    result = await diacritize(_context(), _SOURCE)
+
+    assert result == _SOURCE
+
+
+@pytest.mark.asyncio
+async def test_diacritize_returns_harakat_when_ai_succeeds(monkeypatch: Any) -> None:
+    async def ok(*args: Any, **kwargs: Any) -> DiacritizationResult:
+        return DiacritizationResult(diacritized_text=_VOCALIZED)
+
+    monkeypatch.setattr(agents.diacritize, "complete_json", ok)
+
+    result = await diacritize(_context(), _SOURCE)
+
+    assert result == _VOCALIZED
+
+
+@pytest.mark.asyncio
+async def test_diacritize_rejects_word_altering_output(monkeypatch: Any) -> None:
+    async def altered(*args: Any, **kwargs: Any) -> DiacritizationResult:
+        return DiacritizationResult(diacritized_text="اللهم اغفر لي فقط")
+
+    monkeypatch.setattr(agents.diacritize, "complete_json", altered)
+
+    result = await diacritize(_context(), _SOURCE)
+
+    assert result == _SOURCE

--- a/apps/api/tests/test_reaper.py
+++ b/apps/api/tests/test_reaper.py
@@ -1,0 +1,124 @@
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import pytest
+from arq import ArqRedis
+from src.features.ingestion.reaper import (
+    GIVE_UP_MINUTES,
+    STALE_MINUTES,
+    _parse_timestamp,
+    reap_stuck_prayers,
+)
+from src.shared.config.settings import Settings
+from src.shared.queue.context import WorkerContext
+
+
+def _iso(minutes_ago: float) -> str:
+    stamp = datetime.now(tz=UTC) - timedelta(minutes=minutes_ago)
+    return stamp.strftime("%Y-%m-%d %H:%M:%S.000Z")
+
+
+class FakePocketBase:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self._records = records
+        self.updated: list[tuple[str, dict[str, Any]]] = []
+
+    async def list_records(
+        self, collection: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {"items": self._records}
+
+    async def update_record(
+        self, collection: str, record_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.updated.append((record_id, payload))
+        return {"id": record_id, **payload}
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.jobs: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def enqueue_job(self, name: str, *args: Any) -> None:
+        self.jobs.append((name, args))
+
+
+def _context(pocketbase: FakePocketBase) -> WorkerContext:
+    return WorkerContext(
+        settings=Settings(ai_model="test-model"),
+        pocketbase=cast(Any, pocketbase),
+        ai=cast(Any, None),
+        http=cast(Any, None),
+    )
+
+
+def _record(prayer_id: str, status: str, age_minutes: float) -> dict[str, Any]:
+    return {
+        "id": prayer_id,
+        "status": status,
+        "created": _iso(age_minutes),
+        "updated": _iso(age_minutes),
+    }
+
+
+def test_parse_timestamp_handles_pocketbase_format() -> None:
+    parsed = _parse_timestamp("2026-07-21 12:05:33.142Z")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+    assert parsed.year == 2026 and parsed.hour == 12
+
+
+def test_parse_timestamp_rejects_garbage() -> None:
+    assert _parse_timestamp("not a date") is None
+    assert _parse_timestamp("") is None
+
+
+@pytest.mark.asyncio
+async def test_fresh_prayer_is_left_alone() -> None:
+    pb = FakePocketBase([_record("p1", "processing", STALE_MINUTES - 1)])
+    redis = FakeRedis()
+    await reap_stuck_prayers(_context(pb), cast(ArqRedis, redis))
+    assert redis.jobs == []
+    assert pb.updated == []
+
+
+@pytest.mark.asyncio
+async def test_stuck_processing_prayer_is_requeued() -> None:
+    pb = FakePocketBase([_record("p1", "processing", STALE_MINUTES + 1)])
+    redis = FakeRedis()
+    await reap_stuck_prayers(_context(pb), cast(ArqRedis, redis))
+    assert redis.jobs == [("process_prayer", ("p1",))]
+    assert pb.updated == []
+
+
+@pytest.mark.asyncio
+async def test_stuck_pending_prayer_is_requeued() -> None:
+    pb = FakePocketBase([_record("p1", "pending", STALE_MINUTES + 2)])
+    redis = FakeRedis()
+    await reap_stuck_prayers(_context(pb), cast(ArqRedis, redis))
+    assert redis.jobs == [("process_prayer", ("p1",))]
+
+
+@pytest.mark.asyncio
+async def test_ancient_prayer_is_failed_not_requeued() -> None:
+    pb = FakePocketBase([_record("p1", "processing", GIVE_UP_MINUTES + 1)])
+    redis = FakeRedis()
+    await reap_stuck_prayers(_context(pb), cast(ArqRedis, redis))
+    assert redis.jobs == []
+    assert pb.updated and pb.updated[0][0] == "p1"
+    assert pb.updated[0][1]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_routes_each_prayer_correctly() -> None:
+    pb = FakePocketBase(
+        [
+            _record("fresh", "processing", STALE_MINUTES - 1),
+            _record("stuck", "processing", STALE_MINUTES + 5),
+            _record("ancient", "pending", GIVE_UP_MINUTES + 10),
+        ]
+    )
+    redis = FakeRedis()
+    await reap_stuck_prayers(_context(pb), cast(ArqRedis, redis))
+    assert redis.jobs == [("process_prayer", ("stuck",))]
+    assert [r[0] for r in pb.updated] == ["ancient"]


### PR DESCRIPTION
## What happened

A du'a a user submitted sat in `processing` for **40 hours**. From the worker log:

```
process_prayer('g22lolc01a963bc')
POST https://api.groq.com/.../chat/completions "HTTP/1.1 400 Bad Request"   (x3)
ERROR process_prayer failed, UpstreamError: ai_structured_output_failed:DiacritizationResult
```

The pipeline cleared compliance, spelling, and dedup, then Groq's structured-output endpoint returned `400 json_validate_failed` on **diacritization**. Re-running the pipeline by hand processed the exact same text cleanly, so this was a **transient Groq glitch, not the content**. The prayer is now `confirmed` and live.

## Two faults, both fixed

**1. Root cause — the cosmetic step failed the whole pipeline.** `diacritize()` is *designed* to degrade: when it can't get valid harakat it logs `diacritization_fallback_plain` and returns plain text, because diacritics are cosmetic and the du'a is valid without them. But `_add_harakat` → `complete_json` **raises** `UpstreamError` on a Groq 400, and that exception flew straight past the fallback and killed the job. Now the AI call is caught and falls through to the plain-text path it was always meant to. The verify pass degrades the same way.

**2. No safety net — stuck meant stuck forever.** Once any step hard-failed, the prayer stayed in `processing` with nothing to recover it (arq did not retry through to the `finalize_failed` path). Added a **reaper cron** (every 10 min) that:
- re-enqueues any prayer stuck in `pending` or `processing` past **5 minutes** (normal processing is ~30s),
- marks as `failed` anything stuck past **6 hours**, so a genuinely broken record can't loop forever.

The reaper covers a transient failure in **any** step, not just diacritization — that's the "never again" guarantee.

## Verification

- 10 new tests (reaper routing + timestamp parsing; diacritize fallback / success / word-alteration guard). Full suite **80 passed**, ruff and mypy clean (107 files).
- Ran the reaper against **production**: 0 stuck prayers (the stranded one already recovered), runs clean, touches nothing healthy.
- Confirmed `g22lolc01a963bc` is `confirmed` and served by the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb