### PR TITLE
fix(api): install procps so the X worker healthcheck works on the slim image

### DIFF
--- a/apps/api/Dockerfile.x
+++ b/apps/api/Dockerfile.x
@@ -22,6 +22,10 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 ENV PATH="/app/.venv/bin:$PATH"
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends procps \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --system app && useradd --system --gid app --no-create-home app
 
 WORKDIR /app

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",


### PR DESCRIPTION
The twikit switch (#35) moved the x-worker to `python:3.14-slim`. The healthcheck uses `pgrep`, which the old Playwright base had but slim doesn't (`procps` isn't installed). So the build succeeded, the container started, the healthcheck errored, and Coolify **rolled back to the stale Playwright image** — the twikit code never actually ran.

Adds `procps` to the runtime stage. Verified locally that `pgrep` resolves in the built image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb