### PR TITLE
feat(api): rebuild the X poster on patchright (real browser, undetected)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,10 +22,11 @@ DISCORD_BOT_TOKEN=
 DISCORD_GUILD_ID=
 DISCORD_ALERT_CHANNEL_ID=
 
-# X posting via twikit (X's internal API, no developer key).
+# X posting via a real browser (patchright, no developer key, no API cost).
 # X_SESSION_STATE is {"auth_token":"...","ct0":"..."} copied from a logged-in
 # browser: uv run python -m scripts.build_x_session. Store it in Infisical.
 X_ENABLED=false
 X_HANDLE=ad3oni_
 X_SESSION_STATE=
 X_DRY_RUN=false
+X_HEADLESS=true

--- a/apps/api/Dockerfile.x
+++ b/apps/api/Dockerfile.x
@@ -1,42 +1,30 @@
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS builder
+FROM mcr.microsoft.com/playwright/python:v1.61.0-noble AS runtime
 
-ENV UV_COMPILE_BYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
 ENV UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 WORKDIR /app
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 COPY pyproject.toml uv.lock ./
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev --group x
+RUN uv sync --frozen --no-install-project --no-dev --group x
+
+# Patchright's patched Chromium. Branded Google Chrome does not ship for Linux
+# arm64, and the server is arm64, so channel="chrome" is unavailable; this
+# patched Chromium is the arm64 option and still fixes the webdriver/CDP leaks.
+RUN patchright install chromium
 
 COPY src ./src
 COPY scripts ./scripts
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --group x
-
-FROM python:3.14-slim-bookworm AS runtime
-
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONPATH=/app
-ENV PATH="/app/.venv/bin:$PATH"
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends procps \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN groupadd --system app && useradd --system --gid app --no-create-home app
-
-WORKDIR /app
-
-COPY --from=builder --chown=app:app /app/.venv /app/.venv
-COPY --from=builder --chown=app:app /app/src /app/src
-COPY --from=builder --chown=app:app /app/scripts /app/scripts
-
-USER app
-
 HEALTHCHECK --interval=60s --timeout=10s --start-period=20s --retries=3 \
     CMD test "$PROCESS" = "once" || pgrep -f "arq src.x_worker" > /dev/null || exit 1
 
-CMD ["sh", "-c", "if [ \"$PROCESS\" = \"once\" ]; then exec python -m scripts.post_daily_to_x; else exec arq src.x_worker.WorkerSettings; fi"]
+# Headed Chrome (patchright's recommended stealth mode) needs a display; xvfb-run
+# provides a virtual one inside the container.
+CMD ["sh", "-c", "if [ \"$PROCESS\" = \"once\" ]; then exec xvfb-run -a python -m scripts.post_daily_to_x; else exec xvfb-run -a arq src.x_worker.WorkerSettings; fi"]

--- a/apps/api/X_POSTING.md
+++ b/apps/api/X_POSTING.md
@@ -1,25 +1,28 @@
 # Posting the daily du'a to X
 
-This posts through [twikit](https://github.com/d60/twikit), which drives X's
-internal API using a logged-in session's cookies. No developer key, no cost, no
-browser.
+This drives a real browser ([patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright),
+an undetected Playwright fork) with a logged-in session's cookies. No developer
+key, no API cost.
 
-**Read this first.** This is unofficial access, the same category that got the
-account temporarily restricted once already. The realistic failure mode is
-suspension of `@ad3oni_`. The trade was accepted deliberately: the official API
-costs about $0.45/month at one link-free post per day and cannot get the account
-suspended. twikit is also unmaintained since early 2025, so it may break if X
-changes its internal API.
+**Why a browser and not a library.** twikit (X's internal API) broke the moment X
+changed a script file and is unmaintained. A real browser posts through the same
+UI a human uses, so X cannot break it without breaking their own website. That is
+the most sustainable of the free routes.
 
-The feature is inert until `X_ENABLED=true`, so merging it changes nothing.
+**The risk, stated plainly.** This is still automation against X, and the account
+was temporarily restricted once before (by an automated *login*, since removed).
+The realistic worst case is suspension. Mitigations: we never log in (cookies
+only), post once a day (human frequency), and patchright plus a user-agent fix
+hide the automation markers. But the risk is not zero.
+
+The feature is inert until `X_ENABLED=true`.
 
 ## One-time setup
 
 ### 1. Capture a session
 
-**Never log in through automation.** Take the cookies from the browser you are
-already signed into. Make sure it is switched to the account you want to post
-from; if you are signed into several, the active one is what you capture.
+Never log in through automation. Copy the cookies from the browser you are
+already signed into, on the account you want to post from.
 
 1. Open https://x.com in your normal browser as `@ad3oni_`.
 2. DevTools -> Application -> Storage -> Cookies -> `https://x.com`
@@ -28,72 +31,68 @@ from; if you are signed into several, the active one is what you capture.
 ```bash
 cd apps/api
 uv sync --group x
+patchright install chromium
 X_AUTH_TOKEN=... X_CT0=... uv run python -m scripts.build_x_session
 uv run python -m scripts.verify_x_session
 ```
 
-`build_x_session` makes no network calls. `verify_x_session` asks X whose session
-this is and fails loudly if it is not `@ad3oni_`, so a personal account cannot be
-wired up by mistake.
+`build_x_session` makes no network calls. `verify_x_session` opens the browser
+read-only, asks X whose session this is, and fails loudly if it is not
+`@ad3oni_` (so a personal account cannot be wired up by mistake). It posts
+nothing.
 
 ### 2. Store the session
 
-`x-session.json` is `{"auth_token":"...","ct0":"..."}`, gitignored, and must stay
-that way. Put its contents in `X_SESSION_STATE`, sync to Infisical, delete the
-local file.
-
-```bash
-# push to Infisical via the sync-env skill, then:
-rm apps/api/x-session.json
-```
+`x-session.json` is `{"auth_token":"...","ct0":"..."}`, gitignored. Put its
+contents in `X_SESSION_STATE`, sync to Infisical, delete the local file.
 
 ### 3. Configure
 
 | Variable | Purpose |
 |---|---|
-| `X_ENABLED` | Master switch. Leave `false` until you have tested. |
+| `X_ENABLED` | Master switch. Leave `false` until tested. |
 | `X_SESSION_STATE` | The captured cookies. Bootstraps Redis on first run. |
 | `X_HANDLE` | The account to post from and verify against. Default `ad3oni_`. |
-| `X_DRY_RUN` | Logs the post text and exits without posting. |
+| `X_HEADLESS` | `true` in production. Headed needs a real display. |
+| `X_DRY_RUN` | Logs the post text and exits without opening a browser. |
 | `DISCORD_ALERT_CHANNEL_ID` | Where failures are reported. Strongly recommended. |
 
-### 4. Dry run
+## Stealth notes
 
-```bash
-X_ENABLED=true X_DRY_RUN=true uv run python -m scripts.post_daily_to_x
-```
-
-Confirms prayer selection and formatting without touching X.
-
-## Deploying
-
-Built from `Dockerfile.x` (a slim, browserless image, ~330MB). Runs as the
-`ad3oni-x-worker` Coolify app, an arq worker on its own queue `ad3oni:x:queue`
-with an 08:00 Mecca cron. `PROCESS=once` runs a single post and exits, for dry
-runs and manual triggers.
+- Real browser via **patchright**, which patches `navigator.webdriver`, CDP
+  leaks, and the automation command flags before the page loads.
+- Headless Chromium leaks `HeadlessChrome` in the user-agent; the poster detects
+  the real UA and strips the `Headless` token so it matches genuine Chrome of the
+  same version (client hints stay consistent).
+- Branded Google Chrome (`channel="chrome"`, whose real TLS fingerprint is
+  strongest) does not ship for Linux arm64, and the server is arm64, so we use
+  patchright's patched Chromium instead.
+- Persistent browser profile at `/tmp/ad3oni-x-profile` for a consistent
+  fingerprint across runs.
 
 ## How it behaves
 
-- **Session lives in Redis** at `ad3oni:x:session`, refreshed after every post.
-  X rotates `ct0`, so writing the refreshed cookies back is what keeps the session
-  alive. `X_SESSION_STATE` is only a bootstrap.
-- **Posts are deduplicated** per Mecca day at `ad3oni:x:posted:<date>`, so a retry
-  or double-fire cannot post twice. A `DuplicateTweet` from X is treated as a
-  success (X rejects identical posts).
-- **Every post is verified** by the tweet id X returns from `create_tweet`. No id
-  means the post is reported as a failure, not assumed to have worked.
-- **Wrong-account guard**: before posting, the session's handle is checked against
-  `X_HANDLE`. A personal-account session is refused, not posted to.
-- **Du'as longer than 280 characters are skipped**, not truncated, and an alert is
-  sent. About 2 of 83 current prayers are affected. X counts each haraka as a
-  character, so vocalised text is much longer than it looks.
-- **The bot never logs in.** If the session expires or the account is locked it
-  raises, alerts, and stops. Re-run step 1.
+- **Cookies live in Redis** at `ad3oni:x:session`, refreshed after each post
+  (X rotates `ct0`). `X_SESSION_STATE` is only a bootstrap.
+- **Deduplicated** per Mecca day at `ad3oni:x:posted:<date>`.
+- **Verified by reading the profile timeline back** and matching the text. An
+  unverified post is reported as a failure, not assumed.
+- **Wrong-account guard** refuses to post if the session is not `X_HANDLE`.
+- **Du'as over 280 characters are skipped**, not truncated. About 2 of 83
+  current prayers are affected (X counts each haraka).
+- **Never logs in.** If the session expires or the account is locked it raises,
+  alerts to Discord, and stops. Re-capture the session.
+
+## Deploying
+
+Built from `Dockerfile.x` on the Playwright base image (has Chromium deps and
+Xvfb), running as the `ad3oni-x-worker` Coolify app: an arq worker on its own
+queue `ad3oni:x:queue` with an 08:00 Mecca cron. `PROCESS=once` runs a single
+post and exits, for dry runs and manual triggers.
 
 ## When it breaks
 
-It will. Cookies expire, and X changes its internal API without notice (twikit is
-unmaintained). Failures alert to Discord if `DISCORD_ALERT_CHANNEL_ID` is set. If
-posts stop, check that channel first, then re-capture the session. If twikit
-itself breaks against a changed X API, the fallback is the official API, which
-reuses everything here except `src/features/x/poster.py`.
+The fragile surface is the compose UI selectors in `src/features/x/keys.py`
+(`tweetTextarea_0`, `tweetButton`), which change less often than X's internal
+API but still change. Failures alert to Discord. If posts stop, check that
+channel, then re-capture the session.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.2.3"
+version = "0.2.4"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",
@@ -17,7 +17,7 @@ dependencies = [
 
 [dependency-groups]
 x = [
-    "twikit==2.3.3",
+    "patchright==1.61.2",
 ]
 dev = [
     "ruff==0.8.6",
@@ -41,7 +41,7 @@ strict = true
 files = ["src", "tests"]
 
 [[tool.mypy.overrides]]
-module = ["twikit.*"]
+module = ["patchright.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/apps/api/scripts/verify_x_session.py
+++ b/apps/api/scripts/verify_x_session.py
@@ -19,9 +19,12 @@ async def main() -> None:
         print("session file is not a JSON object with auth_token and ct0")
         raise SystemExit(1)
 
-    expected = get_settings().x_handle.lstrip("@")
+    settings = get_settings()
+    expected = settings.x_handle.lstrip("@")
     try:
-        handle = await resolve_handle(cookies)
+        handle = await resolve_handle(
+            cookies, headless=settings.x_headless, channel=settings.x_channel
+        )
     except SessionExpiredError as error:
         print(f"session is NOT valid: {error}")
         raise SystemExit(1) from error

--- a/apps/api/src/features/x/keys.py
+++ b/apps/api/src/features/x/keys.py
@@ -1,7 +1,19 @@
 X_SESSION = "ad3oni:x:session"
 X_LAST_POST = "ad3oni:x:last_post"
 
+HOME_URL = "https://x.com/home"
+COMPOSE_URL = "https://x.com/compose/post"
+PROFILE_URL = "https://x.com/{handle}"
+
+EDITOR = '[data-testid="tweetTextarea_0"]'
+SUBMIT = '[data-testid="tweetButton"]'
+ACCOUNT_SWITCHER = '[data-testid="SideNav_AccountSwitcher_Button"]'
+TWEET_TEXT = '[data-testid="tweetText"]'
+
 MAX_POST_LENGTH = 280
+
+_USER_DATA_DIR = "/tmp/ad3oni-x-profile"
+_UA_PROBE_DIR = "/tmp/ad3oni-x-ua-probe"
 
 
 def posted_key(day: str) -> str:

--- a/apps/api/src/features/x/poster.py
+++ b/apps/api/src/features/x/poster.py
@@ -1,23 +1,35 @@
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import Any, cast
 
-from twikit import Client
-from twikit.errors import (
-    AccountLocked,
-    AccountSuspended,
-    DuplicateTweet,
-    Unauthorized,
+from patchright.async_api import (
+    BrowserContext,
+    Page,
+    async_playwright,
+)
+from patchright.async_api import (
+    TimeoutError as PlaywrightTimeout,
 )
 
+from src.features.x.keys import (
+    _UA_PROBE_DIR,
+    _USER_DATA_DIR,
+    ACCOUNT_SWITCHER,
+    COMPOSE_URL,
+    EDITOR,
+    HOME_URL,
+    PROFILE_URL,
+    SUBMIT,
+    TWEET_TEXT,
+)
+from src.features.x.session import Cookies, to_browser_cookies
 from src.shared.logging.setup import get_logger
 
 logger = get_logger("api.x.poster")
 
-_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
-)
-
-Cookies = dict[str, str]
+_VERIFY_SLICE = 30
 
 
 class SessionExpiredError(RuntimeError):
@@ -28,60 +40,150 @@ class WrongAccountError(RuntimeError):
     pass
 
 
+class PostVerificationError(RuntimeError):
+    pass
+
+
 @dataclass(slots=True)
 class PostResult:
     verified: bool
-    tweet_id: str | None
     cookies: Cookies
-    duplicate: bool = False
 
 
-def _client() -> Client:
-    return Client("en-US", user_agent=_USER_AGENT)
-
-
-async def resolve_handle(cookies: Cookies) -> str:
-    client = _client()
-    client.set_cookies(dict(cookies))
-    try:
-        me = await client.user()
-    except (Unauthorized, AccountLocked, AccountSuspended) as exc:
-        raise SessionExpiredError(
-            f"X session is not usable ({type(exc).__name__})."
-        ) from exc
-    return (me.screen_name or "").lstrip("@")
-
-
-async def publish(text: str, *, cookies: Cookies, handle: str) -> PostResult:
-    client = _client()
-    client.set_cookies(dict(cookies))
-
-    try:
-        me = await client.user()
-    except (Unauthorized, AccountLocked, AccountSuspended) as exc:
-        raise SessionExpiredError(
-            f"X session is not usable ({type(exc).__name__}). "
-            "Re-capture with scripts/build_x_session.py."
-        ) from exc
-
-    actual = (me.screen_name or "").lstrip("@").lower()
-    expected = handle.lstrip("@").lower()
-    if actual != expected:
-        raise WrongAccountError(f"session belongs to @{actual}, expected @{expected}")
-
-    try:
-        tweet = await client.create_tweet(text=text)
-    except DuplicateTweet:
-        logger.info("x_duplicate_tweet already_posted")
-        return PostResult(
-            verified=True, tweet_id=None, cookies=client.get_cookies(), duplicate=True
-        )
-    except (Unauthorized, AccountLocked, AccountSuspended) as exc:
-        raise SessionExpiredError(f"X rejected the post ({type(exc).__name__}).") from exc
-
-    tweet_id = getattr(tweet, "id", None)
-    return PostResult(
-        verified=bool(tweet_id),
-        tweet_id=tweet_id,
-        cookies=client.get_cookies(),
+async def _detect_clean_user_agent(playwright: Any, channel: str, headless: bool) -> str | None:
+    if not headless:
+        return None
+    probe = await playwright.chromium.launch_persistent_context(
+        user_data_dir=_UA_PROBE_DIR,
+        channel=channel or None,
+        headless=headless,
+        no_viewport=True,
     )
+    try:
+        page = await probe.new_page()
+        agent: str = await page.evaluate("() => navigator.userAgent")
+    finally:
+        await probe.close()
+    if "HeadlessChrome" not in agent:
+        return None
+    return agent.replace("HeadlessChrome", "Chrome")
+
+
+@asynccontextmanager
+async def _context(
+    cookies: Cookies, *, headless: bool, channel: str, timeout_ms: int
+) -> AsyncIterator[BrowserContext]:
+    async with async_playwright() as playwright:
+        user_agent = await _detect_clean_user_agent(playwright, channel, headless)
+        context = await playwright.chromium.launch_persistent_context(
+            user_data_dir=_USER_DATA_DIR,
+            channel=channel or None,
+            headless=headless,
+            no_viewport=True,
+            user_agent=user_agent,
+        )
+        context.set_default_timeout(timeout_ms)
+        context.set_default_navigation_timeout(timeout_ms)
+        await context.add_cookies(cast("Any", to_browser_cookies(cookies)))
+        try:
+            yield context
+        finally:
+            await context.close()
+
+
+async def _current_cookies(context: BrowserContext) -> Cookies:
+    wanted = {"auth_token", "ct0"}
+    return {
+        c["name"]: c["value"]
+        for c in await context.cookies("https://x.com")
+        if c["name"] in wanted
+    }
+
+
+async def _assert_logged_in(page: Page, handle: str) -> None:
+    await page.goto(HOME_URL, wait_until="domcontentloaded")
+    try:
+        await page.wait_for_selector(ACCOUNT_SWITCHER)
+    except PlaywrightTimeout as exc:
+        raise SessionExpiredError(
+            "X did not render a logged-in timeline; the session is invalid or "
+            "the account is restricted."
+        ) from exc
+
+    label = await page.locator(ACCOUNT_SWITCHER).inner_text()
+    actual = next(
+        (part.lstrip("@") for part in label.split() if part.startswith("@")), ""
+    )
+    if actual.lower() != handle.lstrip("@").lower():
+        raise WrongAccountError(
+            f"session belongs to @{actual or 'unknown'}, expected @{handle}"
+        )
+
+
+async def _compose(page: Page, text: str) -> None:
+    await page.goto(COMPOSE_URL, wait_until="domcontentloaded")
+    editor = page.locator(EDITOR)
+    await editor.wait_for(state="visible")
+    await editor.click()
+    await page.keyboard.insert_text(text)
+
+    submit = page.locator(SUBMIT)
+    await submit.wait_for(state="visible")
+    if await submit.is_disabled():
+        raise PostVerificationError("compose button stayed disabled; text rejected")
+
+    modifier = "Meta" if sys.platform == "darwin" else "Control"
+    await page.keyboard.press(f"{modifier}+Enter")
+
+
+async def _confirm_on_profile(page: Page, handle: str, text: str) -> bool:
+    await page.goto(
+        PROFILE_URL.format(handle=handle.lstrip("@")), wait_until="domcontentloaded"
+    )
+    try:
+        await page.wait_for_selector(TWEET_TEXT)
+    except PlaywrightTimeout:
+        return False
+    needle = text[:_VERIFY_SLICE].strip()
+    count = min(await page.locator(TWEET_TEXT).count(), 5)
+    for index in range(count):
+        if needle in await page.locator(TWEET_TEXT).nth(index).inner_text():
+            return True
+    return False
+
+
+async def resolve_handle(cookies: Cookies, *, headless: bool, channel: str) -> str:
+    async with _context(
+        cookies, headless=headless, channel=channel, timeout_ms=45_000
+    ) as context:
+        page = await context.new_page()
+        await page.goto(HOME_URL, wait_until="domcontentloaded")
+        try:
+            await page.wait_for_selector(ACCOUNT_SWITCHER)
+        except PlaywrightTimeout as exc:
+            raise SessionExpiredError("session invalid or restricted") from exc
+        label = await page.locator(ACCOUNT_SWITCHER).inner_text()
+        return next(
+            (p.lstrip("@") for p in label.split() if p.startswith("@")), ""
+        )
+
+
+async def publish(
+    text: str,
+    *,
+    cookies: Cookies,
+    handle: str,
+    headless: bool,
+    channel: str,
+    timeout_ms: int,
+) -> PostResult:
+    async with _context(
+        cookies, headless=headless, channel=channel, timeout_ms=timeout_ms
+    ) as context:
+        page = await context.new_page()
+        await _assert_logged_in(page, handle)
+        await _compose(page, text)
+        await page.wait_for_timeout(3000)
+        verified = await _confirm_on_profile(page, handle, text)
+        cookies_out = await _current_cookies(context)
+        return PostResult(verified=verified, cookies=cookies_out or cookies)

--- a/apps/api/src/features/x/service.py
+++ b/apps/api/src/features/x/service.py
@@ -81,7 +81,14 @@ async def post_daily_to_x(context: WorkerContext, redis: ArqRedis) -> bool:
         return False
 
     try:
-        result = await publish(text, cookies=cookies, handle=settings.x_handle)
+        result = await publish(
+            text,
+            cookies=cookies,
+            handle=settings.x_handle,
+            headless=settings.x_headless,
+            channel=settings.x_channel,
+            timeout_ms=settings.x_nav_timeout_ms,
+        )
     except SessionExpiredError as error:
         logger.error("x_session_expired")
         await _alert(context, f"انتهت صلاحية الجلسة: {error}")

--- a/apps/api/src/features/x/session.py
+++ b/apps/api/src/features/x/session.py
@@ -56,3 +56,18 @@ async def load_session(redis: ArqRedis, bootstrap: str) -> Cookies | None:
 
 async def save_session(redis: ArqRedis, cookies: Cookies) -> None:
     await redis.set(X_SESSION, json.dumps(cookies))
+
+
+def to_browser_cookies(cookies: Cookies) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "value": value,
+            "domain": ".x.com",
+            "path": "/",
+            "secure": True,
+            "httpOnly": name == "auth_token",
+            "sameSite": "None" if name == "auth_token" else "Lax",
+        }
+        for name, value in cookies.items()
+    ]

--- a/apps/api/src/shared/config/settings.py
+++ b/apps/api/src/shared/config/settings.py
@@ -64,6 +64,9 @@ class Settings(BaseSettings):
     x_handle: str = "ad3oni_"
     x_session_state: str = ""
     x_dry_run: bool = False
+    x_headless: bool = True
+    x_channel: str = ""
+    x_nav_timeout_ms: int = 45_000
 
     @property
     def is_production(self) -> bool:

--- a/apps/api/tests/test_x.py
+++ b/apps/api/tests/test_x.py
@@ -6,7 +6,12 @@ from arq import ArqRedis
 from src.features.prayers.schema import Prayer
 from src.features.x.keys import MAX_POST_LENGTH, X_SESSION
 from src.features.x.service import compose_post
-from src.features.x.session import load_session, parse_cookies, save_session
+from src.features.x.session import (
+    load_session,
+    parse_cookies,
+    save_session,
+    to_browser_cookies,
+)
 
 _COOKIES = {"auth_token": "tok", "ct0": "csrf"}
 
@@ -53,6 +58,15 @@ def test_compose_returns_none_when_prayer_itself_is_too_long() -> None:
 def test_compose_accepts_prayer_at_exactly_the_limit() -> None:
     text = "ا" * MAX_POST_LENGTH
     assert compose_post(_prayer(text)) == text
+
+
+def test_to_browser_cookies_shapes_both_for_x_domain() -> None:
+    browser = to_browser_cookies(_COOKIES)
+    by_name = {c["name"]: c for c in browser}
+    assert set(by_name) == {"auth_token", "ct0"}
+    assert all(c["domain"] == ".x.com" and c["secure"] for c in browser)
+    assert by_name["auth_token"]["httpOnly"] is True
+    assert by_name["ct0"]["httpOnly"] is False
 
 
 def test_parse_cookies_requires_both_tokens() -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.2.1"
+version = "0.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },
@@ -58,7 +58,7 @@ dev = [
     { name = "types-croniter" },
 ]
 x = [
-    { name = "twikit" },
+    { name = "patchright" },
 ]
 
 [package.metadata]
@@ -83,7 +83,7 @@ dev = [
     { name = "ruff", specifier = "==0.8.6" },
     { name = "types-croniter", specifier = ">=6.2.2.20260518" },
 ]
-x = [{ name = "twikit", specifier = "==2.3.3" }]
+x = [{ name = "patchright", specifier = "==1.61.2" }]
 
 [[package]]
 name = "arq"
@@ -96,19 +96,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a4/81/7f9db65a89c29ba374000309b9dd95509500045df5c7e22f26c3731b7380/arq-0.28.0.tar.gz", hash = "sha256:a458188aefc2d7ee17d136f80d8fa8df1d6eba4ceebdead87e9f172d027dc311", size = 416141, upload-time = "2026-04-16T10:50:23.893Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/32/66b616976c5058d434ca2017979bfffd784888177b16b5038abcec93954a/arq-0.28.0-py3-none-any.whl", hash = "sha256:b1696bf5614d60f4172a2c0cbdc177e23ba03a5eb9acc29bd8181f4ea71fff94", size = 26061, upload-time = "2026-04-16T10:50:22.321Z" },
-]
-
-[[package]]
-name = "beautifulsoup4"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -224,12 +211,50 @@ wheels = [
 ]
 
 [[package]]
-name = "filetype"
-version = "1.2.0"
+name = "greenlet"
+version = "3.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
 ]
 
 [[package]]
@@ -327,11 +352,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
-[package.optional-dependencies]
-socks = [
-    { name = "socksio" },
-]
-
 [[package]]
 name = "idna"
 version = "3.17"
@@ -386,20 +406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "js2py-3-13"
-version = "0.74.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjsparser" },
-    { name = "six" },
-    { name = "tzlocal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/9e/17ed2ceebff1539a454b66d3f056001ab37f679e28a336e1ba88407940fe/js2py_3_13-0.74.1.tar.gz", hash = "sha256:91e214f717312f9d510eaf36fcc5325b0b15a22a49831fe2b434bca4a33c1f77", size = 570397, upload-time = "2025-02-07T13:01:33.395Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/5f/4bdab35d30055613c58f681f03d3a76e06c874485aced646fac763a1d552/Js2Py_3.13-0.74.1-py3-none-any.whl", hash = "sha256:5c60a80a43197775986c27f33becaf9ebf3731e8e79030c925f44025ed6f0e8b", size = 611795, upload-time = "2025-02-07T13:01:31.087Z" },
-]
-
-[[package]]
 name = "limits"
 version = "5.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -411,59 +417,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
-]
-
-[[package]]
-name = "lxml"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
-    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
-    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
-    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
-    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
-    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
-    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
-    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
-    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
-    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
-    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
-    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
-]
-
-[[package]]
-name = "m3u8"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/a5/73697aaa99bb32b610adc1f11d46a0c0c370351292e9b271755084a145e6/m3u8-6.0.0.tar.gz", hash = "sha256:7ade990a1667d7a653bcaf9413b16c3eb5cd618982ff46aaff57fe6d9fa9c0fd", size = 42720, upload-time = "2024-08-07T11:20:06.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/31/50f3c38b38ff28635ff9c4a4afefddccc5f1b57457b539bdbdf75ce18669/m3u8-6.0.0-py3-none-any.whl", hash = "sha256:566d0748739c552dad10f8c87150078de6a0ec25071fa48e6968e96fc6dcba5d", size = 24133, upload-time = "2024-08-07T11:20:03.96Z" },
 ]
 
 [[package]]
@@ -514,6 +467,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "patchright"
+version = "1.61.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/a76e2ea17dd4feccbf5ef6df017fb2e67f4b72a6f559f59d9aad1197f83a/patchright-1.61.2-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:43ae10cd2a3e46b222179a120ab39ba88f801f3a42aa41cab45fac9928f2103d", size = 43727572, upload-time = "2026-07-05T21:17:52.382Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e7/1ff89853c9aeaf26cd20559f401375ec71a40e4041cf7ace03d41a741f06/patchright-1.61.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a3da24d7890631255c7bef467b94ffe7f7bfa36f96fc72c10d5787d3cb396873", size = 42512921, upload-time = "2026-07-05T21:17:55.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/d730536a7fc43c3aaf2781518595ca71ffa1fc2f24e580c0d0cf04e00eca/patchright-1.61.2-py3-none-macosx_11_0_universal2.whl", hash = "sha256:edef852aa7d28791fa2d3f7ce135edfea2ce07a2bc5e0a74fb2dfe269af62223", size = 43727573, upload-time = "2026-07-05T21:17:59.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b5/c76dcda275cb0d9651321e343f3268609ae24cef196bff56751754ffba16/patchright-1.61.2-py3-none-manylinux1_x86_64.whl", hash = "sha256:545bdf2c0bb5f9ad78ab315e91c8c2990cc6a702e7f18650b71fe1071049b5c1", size = 47729338, upload-time = "2026-07-05T21:18:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ef/5de6feaedf47a6ba8efb9e8c4f8a42bad29cc59c35bbd088b1729a36b271/patchright-1.61.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1824da30cf6560749bc1bb4a7f002fec325d5b709090dd7c8c1b643899331cee", size = 47426969, upload-time = "2026-07-05T21:18:06.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6e/ce2c5d03a4c785ac8f3e0180bbf83ef85149cf41fdfa41c09bd8cbcfd945/patchright-1.61.2-py3-none-win32.whl", hash = "sha256:a5aaf4cec2bd38714f2447f84bcdfe7dcb592a16e9616bf6d2d872066d1c78af", size = 38155048, upload-time = "2026-07-05T21:18:09.938Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/fceb57b9d32ed078f53fc6a757c6e4b54cb117f59412938252a3359105e5/patchright-1.61.2-py3-none-win_amd64.whl", hash = "sha256:506bca9b72e609fd8fee35e2a3ad26e5d92e25337002f5c2cdad53d5cacb0b67", size = 38155052, upload-time = "2026-07-05T21:18:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/33/96/67a791c6b7cd76424b44d356beaf414ab97c3aef2d42fad4641e7905b41d/patchright-1.61.2-py3-none-win_arm64.whl", hash = "sha256:3dee1e2daada9f98653763831f688d39c924e0cf0eeb988e8047b703766cee73", size = 34268624, upload-time = "2026-07-05T21:18:15.966Z" },
 ]
 
 [[package]]
@@ -604,10 +576,16 @@ wheels = [
 ]
 
 [[package]]
-name = "pyjsparser"
-version = "2.7.1"
+name = "pyee"
+version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/ef/c72abcfa2c6accd03e7c89c400790fc3d908c5804d50a7c4e9ceabd74d23/pyjsparser-2.7.1.tar.gz", hash = "sha256:be60da6b778cc5a5296a69d8e7d614f1f870faf94e1b1b6ac591f2ad5d729579", size = 24196, upload-time = "2019-04-21T21:56:17.708Z" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
 
 [[package]]
 name = "pynacl"
@@ -642,15 +620,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
     { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
     { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
-]
-
-[[package]]
-name = "pyotp"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/c6/c5d96a86fd0bf6fa1bbb5c5c341ff3208638b692727a683c8289068d9a11/pyotp-2.10.0.tar.gz", hash = "sha256:d01e9703443616b03c57c700b5cbffd56a1f929c1b0f8f03131bc78c1fca9d3f", size = 18625, upload-time = "2026-06-14T03:48:49.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/33/7b83bde70eddaaaaef487751a9c3a5cc0c0be54620ded0e120ebdc401ff9/pyotp-2.10.0-py3-none-any.whl", hash = "sha256:1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c", size = 13768, upload-time = "2026-06-14T03:48:47.831Z" },
 ]
 
 [[package]]
@@ -797,24 +766,6 @@ wheels = [
 ]
 
 [[package]]
-name = "socksio"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
-]
-
-[[package]]
-name = "soupsieve"
-version = "2.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
-]
-
-[[package]]
 name = "starlette"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -836,25 +787,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
-]
-
-[[package]]
-name = "twikit"
-version = "2.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "filetype" },
-    { name = "httpx", extra = ["socks"] },
-    { name = "js2py-3-13" },
-    { name = "lxml" },
-    { name = "m3u8" },
-    { name = "pyotp" },
-    { name = "webvtt-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/1e/bb8bfff056eb46b4645780f65b710ea5b83d522deba573652174d858178a/twikit-2.3.3.tar.gz", hash = "sha256:081177a8a1b05f3d67e5622d839bba2a63422c07cea31b906f89df67ae8166da", size = 71141, upload-time = "2025-02-07T14:40:36.709Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/e0/69c125e558c429a58e6adcf87880b70baea980898eee4ea855e6d3b7822a/twikit-2.3.3-py3-none-any.whl", hash = "sha256:0d745895bb243f84a1bbb8c9c821f165a0f60e20db27dee66fdb77d05af748fd", size = 82863, upload-time = "2025-02-07T14:40:34.649Z" },
 ]
 
 [[package]]
@@ -885,27 +817,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "tzdata"
-version = "2026.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
 ]
 
 [[package]]
@@ -1024,15 +935,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "webvtt-py"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f6/7c9c964681fb148e0293e6860108d378e09ccab2218f9063fd3eb87f840a/webvtt-py-0.5.1.tar.gz", hash = "sha256:2040dd325277ddadc1e0c6cc66cbc4a1d9b6b49b24c57a0c3364374c3e8a3dc1", size = 55128, upload-time = "2024-05-30T13:40:17.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/ed/aad7e0f5a462d679f7b4d2e0d8502c3096740c883b5bbed5103146480937/webvtt_py-0.5.1-py3-none-any.whl", hash = "sha256:9d517d286cfe7fc7825e9d4e2079647ce32f5678eb58e39ef544ffbb932610b7", size = 19802, upload-time = "2024-05-30T13:40:14.661Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
twikit is [confirmed broken for everyone since 2026-03-18](https://github.com/d60/twikit/issues/408) and unmaintained. Replaced with a **real browser** via [patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright) (an undetected Playwright fork).

## Why a browser is the sustainable choice

A real browser posts through the same UI a human uses — **X cannot break it without breaking their own website**. That's the opposite of twikit/internal-API approaches that break whenever X changes a script. This directly answers the "must keep working" goal.

## Stealth — verified in the built image, not assumed

Threat model in our favour: **authenticated, once-a-day, not scraping** — X is lenient with a real logged-in session at human frequency.

| Signal | Handling | Verified |
|---|---|---|
| `navigator.webdriver` | patchright patches it | `False` ✓ |
| CDP / command-flag leaks | patchright, pre-page-load | ✓ |
| `HeadlessChrome` in user-agent | detect real UA, strip `Headless` token (keeps client hints consistent) | leak closed ✓ |
| TLS/JA3 (branded Chrome) | no arm64 Chrome build; server is arm64 → patched Chromium | best available on arm64 |

I built the image locally and confirmed: builds on arm64, Chromium launches, real navigation to x.com works, `navigator.webdriver=False`, and the UA no longer contains `HeadlessChrome`.

## Design

- **No login, ever** — cookies only. Automated login is what restricted the account before.
- **Headless by default.** Headed-under-Xvfb hung in Docker's nested VM; for an unattended daily cron, reliable headless beats a headed browser that might hang and silently never post. Toggle exists (`X_HEADLESS`).
- Compose via keyboard (`insert_text` + `Ctrl+Enter`) — more resilient than the post-button selector.
- Verify by reading the profile timeline back; wrong-account guard refuses a non-`X_HANDLE` session.
- Cookies refresh to Redis after each post.

## Verification

`ruff`, `mypy` (107 files), **81 tests** clean. Image + browser + UA-fix proven locally. The live posting path itself needs a captured session (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb