### PR TITLE
fix(api): target the first compose textarea and button

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.2.5"
+version = "0.2.6"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/x/poster.py
+++ b/apps/api/src/features/x/poster.py
@@ -123,12 +123,12 @@ async def _assert_logged_in(page: Page, handle: str) -> None:
 
 async def _compose(page: Page, text: str) -> None:
     await page.goto(COMPOSE_URL, wait_until="domcontentloaded")
-    editor = page.locator(EDITOR)
+    editor = page.locator(EDITOR).first
     await editor.wait_for(state="visible")
     await editor.click()
     await page.keyboard.insert_text(text)
 
-    submit = page.locator(SUBMIT)
+    submit = page.locator(SUBMIT).first
     await submit.wait_for(state="visible")
     if await submit.is_disabled():
         raise PostVerificationError("compose button stayed disabled; text rejected")

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.2.4"
+version = "0.2.5"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
The live post reached the composer logged in as `@ad3oni_` but hit a strict-mode violation: `x.com/compose/post` renders **two** `tweetTextarea_0` elements (inline composer + modal), so the locator matched both and `click()` failed. Use `.first` for the editor and submit locators.

Everything up to the compose step works on the server; only the selector was ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb