### PR TITLE
fix(api): single-launch browser and reliable post-completion wait

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.2.6"
+version = "0.2.7"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/x/keys.py
+++ b/apps/api/src/features/x/keys.py
@@ -13,7 +13,6 @@ TWEET_TEXT = '[data-testid="tweetText"]'
 MAX_POST_LENGTH = 280
 
 _USER_DATA_DIR = "/tmp/ad3oni-x-profile"
-_UA_PROBE_DIR = "/tmp/ad3oni-x-ua-probe"
 
 
 def posted_key(day: str) -> str:

--- a/apps/api/src/features/x/poster.py
+++ b/apps/api/src/features/x/poster.py
@@ -14,7 +14,6 @@ from patchright.async_api import (
 )
 
 from src.features.x.keys import (
-    _UA_PROBE_DIR,
     _USER_DATA_DIR,
     COMPOSE_URL,
     EDITOR,
@@ -50,37 +49,16 @@ class PostResult:
     cookies: Cookies
 
 
-async def _detect_clean_user_agent(playwright: Any, channel: str, headless: bool) -> str | None:
-    if not headless:
-        return None
-    probe = await playwright.chromium.launch_persistent_context(
-        user_data_dir=_UA_PROBE_DIR,
-        channel=channel or None,
-        headless=headless,
-        no_viewport=True,
-    )
-    try:
-        page = await probe.new_page()
-        agent: str = await page.evaluate("() => navigator.userAgent")
-    finally:
-        await probe.close()
-    if "HeadlessChrome" not in agent:
-        return None
-    return agent.replace("HeadlessChrome", "Chrome")
-
-
 @asynccontextmanager
 async def _context(
     cookies: Cookies, *, headless: bool, channel: str, timeout_ms: int
 ) -> AsyncIterator[BrowserContext]:
     async with async_playwright() as playwright:
-        user_agent = await _detect_clean_user_agent(playwright, channel, headless)
         context = await playwright.chromium.launch_persistent_context(
             user_data_dir=_USER_DATA_DIR,
             channel=channel or None,
             headless=headless,
             no_viewport=True,
-            user_agent=user_agent,
         )
         context.set_default_timeout(timeout_ms)
         context.set_default_navigation_timeout(timeout_ms)
@@ -89,6 +67,21 @@ async def _context(
             yield context
         finally:
             await context.close()
+
+
+async def _new_page(context: BrowserContext, headless: bool) -> Page:
+    page = await context.new_page()
+    if not headless:
+        return page
+    agent: str = await page.evaluate("() => navigator.userAgent")
+    if "HeadlessChrome" not in agent:
+        return page
+    cdp = await context.new_cdp_session(page)
+    await cdp.send(
+        "Network.setUserAgentOverride",
+        {"userAgent": agent.replace("HeadlessChrome", "Chrome")},
+    )
+    return page
 
 
 async def _current_cookies(context: BrowserContext) -> Cookies:
@@ -136,6 +129,13 @@ async def _compose(page: Page, text: str) -> None:
     modifier = "Meta" if sys.platform == "darwin" else "Control"
     await page.keyboard.press(f"{modifier}+Enter")
 
+    # The composer clears/detaches once X accepts the post; wait for that signal
+    # rather than a fixed sleep so verification does not race the send.
+    try:
+        await editor.wait_for(state="detached", timeout=20_000)
+    except PlaywrightTimeout:
+        await page.wait_for_timeout(4000)
+
 
 async def _confirm_on_profile(page: Page, handle: str, text: str) -> bool:
     await page.goto(
@@ -157,7 +157,7 @@ async def resolve_handle(cookies: Cookies, *, headless: bool, channel: str) -> s
     async with _context(
         cookies, headless=headless, channel=channel, timeout_ms=45_000
     ) as context:
-        page = await context.new_page()
+        page = await _new_page(context, headless)
         return await _current_handle(page)
 
 
@@ -173,10 +173,9 @@ async def publish(
     async with _context(
         cookies, headless=headless, channel=channel, timeout_ms=timeout_ms
     ) as context:
-        page = await context.new_page()
+        page = await _new_page(context, headless)
         await _assert_logged_in(page, handle)
         await _compose(page, text)
-        await page.wait_for_timeout(3000)
         verified = await _confirm_on_profile(page, handle, text)
         cookies_out = await _current_cookies(context)
         return PostResult(verified=verified, cookies=cookies_out or cookies)

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.2.5"
+version = "0.2.6"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
The live test **posted successfully** but never recorded success. Cause: the flow did **two full browser launches** (a separate UA probe, then the real one), ~20s each on the server, so the run passed my timeout *after* posting but *before* the verify + Redis mark — a real tweet, no success log, no dedup key.

- **Single launch.** The `HeadlessChrome` UA fix moves from a throwaway probe launch to a per-page CDP `Network.setUserAgentOverride` — roughly halves browser startup cost.
- **Real completion signal.** After `Ctrl+Enter`, wait for the composer to *detach* (X's own accept signal) instead of a fixed 3s sleep, so verification doesn't race the send.

The posting path is already proven live on @ad3oni_; this makes it fast and deterministic enough to finish bookkeeping cleanly. Gates green (81 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQt9JagsuCZxAJEEPmxwXb