### PR TITLE
feat(api): post three daily prayers at randomized times

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.2.7"
+version = "0.3.0"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/scripts/post_daily_to_x.py
+++ b/apps/api/scripts/post_daily_to_x.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import httpx
-from src.features.x.service import post_daily_to_x
+from src.features.x.service import post_one_now
 from src.shared.ai.client import create_ai_client
 from src.shared.config.settings import get_settings
 from src.shared.logging.setup import configure_logging, get_logger
@@ -27,7 +27,7 @@ async def main() -> None:
         await pocketbase.authenticate()
         context = WorkerContext(settings, pocketbase, create_ai_client(settings), http)
         try:
-            posted = await post_daily_to_x(context, redis)
+            posted = await post_one_now(context, redis)
         finally:
             await redis.aclose()
 

--- a/apps/api/src/features/x/keys.py
+++ b/apps/api/src/features/x/keys.py
@@ -14,6 +14,21 @@ MAX_POST_LENGTH = 280
 
 _USER_DATA_DIR = "/tmp/ad3oni-x-profile"
 
+# Mecca-time [start_hour, end_hour) windows. Each day one random minute inside
+# each window is chosen, so the three daily posts are spread and non-uniform.
+POST_WINDOWS: tuple[tuple[int, int], ...] = ((5, 9), (12, 16), (18, 22))
+GRACE_MINUTES = 9
+SLOT_TTL_SECONDS = 60 * 60 * 48
+PICK_TRIES = 6
 
-def posted_key(day: str) -> str:
-    return f"ad3oni:x:posted:{day}"
+
+def plan_key(day: str) -> str:
+    return f"ad3oni:x:plan:{day}"
+
+
+def slot_posted_key(day: str, slot: int) -> str:
+    return f"ad3oni:x:posted:{day}:{slot}"
+
+
+def posted_prayers_key(day: str) -> str:
+    return f"ad3oni:x:posted_prayers:{day}"

--- a/apps/api/src/features/x/poster.py
+++ b/apps/api/src/features/x/poster.py
@@ -114,7 +114,10 @@ async def _assert_logged_in(page: Page, handle: str) -> None:
         )
 
 
-async def _compose(page: Page, text: str) -> None:
+async def _submit(page: Page, text: str) -> None:
+    """Compose and send. Raises only BEFORE the send, so a raise means nothing
+    was posted and the caller may safely retry. Once Ctrl+Enter is pressed the
+    post is committed and this never raises."""
     await page.goto(COMPOSE_URL, wait_until="domcontentloaded")
     editor = page.locator(EDITOR).first
     await editor.wait_for(state="visible")
@@ -129,11 +132,11 @@ async def _compose(page: Page, text: str) -> None:
     modifier = "Meta" if sys.platform == "darwin" else "Control"
     await page.keyboard.press(f"{modifier}+Enter")
 
-    # The composer clears/detaches once X accepts the post; wait for that signal
-    # rather than a fixed sleep so verification does not race the send.
+    # Committed. The composer detaches once X accepts the post; wait for that
+    # signal, best-effort, and never raise past this point.
     try:
         await editor.wait_for(state="detached", timeout=20_000)
-    except PlaywrightTimeout:
+    except Exception:
         await page.wait_for_timeout(4000)
 
 
@@ -175,7 +178,16 @@ async def publish(
     ) as context:
         page = await _new_page(context, headless)
         await _assert_logged_in(page, handle)
-        await _compose(page, text)
-        verified = await _confirm_on_profile(page, handle, text)
-        cookies_out = await _current_cookies(context)
+        await _submit(page, text)
+        # Post is committed. Everything below is best-effort; never raise, so a
+        # verification or cookie hiccup cannot make the caller retry and double
+        # post.
+        try:
+            verified = await _confirm_on_profile(page, handle, text)
+        except Exception:
+            verified = False
+        try:
+            cookies_out = await _current_cookies(context)
+        except Exception:
+            cookies_out = {}
         return PostResult(verified=verified, cookies=cookies_out or cookies)

--- a/apps/api/src/features/x/schedule.py
+++ b/apps/api/src/features/x/schedule.py
@@ -1,0 +1,95 @@
+import json
+import random
+from collections.abc import Awaitable
+from datetime import datetime
+from typing import cast
+from zoneinfo import ZoneInfo
+
+from arq import ArqRedis
+
+from src.features.daily.keys import MECCA_TIMEZONE
+from src.features.x.keys import (
+    GRACE_MINUTES,
+    POST_WINDOWS,
+    SLOT_TTL_SECONDS,
+    X_LAST_POST,
+    plan_key,
+    posted_prayers_key,
+    slot_posted_key,
+)
+from src.features.x.service import pick_postable_prayer, publish_prayer
+from src.shared.logging.setup import get_logger
+from src.shared.queue.context import WorkerContext
+
+logger = get_logger("api.x.schedule")
+
+
+def _decode(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def make_plan() -> list[str]:
+    times: list[str] = []
+    for start, end in POST_WINDOWS:
+        minute = random.randint(0, (end - start) * 60 - 1)
+        total = start * 60 + minute
+        times.append(f"{total // 60:02d}:{total % 60:02d}")
+    return times
+
+
+def is_due(now_minutes: int, target: str) -> bool:
+    target_minutes = int(target[:2]) * 60 + int(target[3:])
+    return target_minutes <= now_minutes <= target_minutes + GRACE_MINUTES
+
+
+async def _plan_for(redis: ArqRedis, day: str) -> list[str]:
+    stored = _decode(await redis.get(plan_key(day)))
+    if stored:
+        loaded: list[str] = json.loads(stored)
+        return loaded
+    plan = make_plan()
+    await redis.set(plan_key(day), json.dumps(plan), ex=SLOT_TTL_SECONDS)
+    logger.info("x_plan_created day=%s times=%s", day, plan)
+    return plan
+
+
+async def dispatch_posts(context: WorkerContext, redis: ArqRedis) -> None:
+    if not context.settings.x_enabled:
+        return
+
+    now = datetime.now(ZoneInfo(MECCA_TIMEZONE))
+    day = now.date().isoformat()
+    plan = await _plan_for(redis, day)
+    now_minutes = now.hour * 60 + now.minute
+
+    for slot, target in enumerate(plan):
+        if not is_due(now_minutes, target):
+            continue
+        if await redis.get(slot_posted_key(day, slot)) is not None:
+            continue
+
+        picked = await pick_postable_prayer(context, redis, day)
+        if picked is None:
+            logger.warning("x_no_postable_prayer day=%s slot=%s", day, slot)
+            continue
+
+        prayer, text = picked
+        if not await publish_prayer(context, redis, prayer, text):
+            continue
+
+        await redis.set(slot_posted_key(day, slot), prayer.id, ex=SLOT_TTL_SECONDS)
+        await cast(
+            "Awaitable[int]", redis.sadd(posted_prayers_key(day), prayer.id)
+        )
+        await cast(
+            "Awaitable[bool]",
+            redis.expire(posted_prayers_key(day), SLOT_TTL_SECONDS),
+        )
+        await redis.set(X_LAST_POST, f"{day}:{slot}:{prayer.id}")
+        logger.info(
+            "x_posted day=%s slot=%s time=%s prayer=%s", day, slot, target, prayer.id
+        )

--- a/apps/api/src/features/x/service.py
+++ b/apps/api/src/features/x/service.py
@@ -1,23 +1,32 @@
+from collections.abc import Awaitable
 from datetime import datetime
+from typing import cast
 from zoneinfo import ZoneInfo
 
 from arq import ArqRedis
 
 from src.features.daily.keys import MECCA_TIMEZONE
-from src.features.daily.service import DailyService
 from src.features.discord.embeds import info_embed
 from src.features.discord.rest import DiscordRest
 from src.features.prayers.schema import Prayer
-from src.features.x.keys import MAX_POST_LENGTH, X_LAST_POST, posted_key
-from src.features.x.poster import SessionExpiredError, WrongAccountError, publish
+from src.features.prayers.service import PrayerService
+from src.features.x.keys import (
+    MAX_POST_LENGTH,
+    PICK_TRIES,
+    posted_prayers_key,
+)
+from src.features.x.poster import (
+    PostVerificationError,
+    SessionExpiredError,
+    WrongAccountError,
+    publish,
+)
 from src.features.x.session import load_session, save_session
 from src.shared.errors.exceptions import NotFoundError
 from src.shared.logging.setup import get_logger
 from src.shared.queue.context import WorkerContext
 
 logger = get_logger("api.x.service")
-
-_POSTED_TTL_SECONDS = 60 * 60 * 48
 
 
 def compose_post(prayer: Prayer) -> str | None:
@@ -31,11 +40,11 @@ def compose_post(prayer: Prayer) -> str | None:
     return text
 
 
-def _today() -> str:
+def today() -> str:
     return datetime.now(ZoneInfo(MECCA_TIMEZONE)).date().isoformat()
 
 
-async def _alert(context: WorkerContext, message: str) -> None:
+async def alert(context: WorkerContext, message: str) -> None:
     channel = context.settings.discord_alert_channel_id
     token = context.settings.discord_bot_token
     if not channel or not token:
@@ -44,40 +53,46 @@ async def _alert(context: WorkerContext, message: str) -> None:
     await rest.post_message(channel, info_embed(f"‏X: {message}"))
 
 
-async def post_daily_to_x(context: WorkerContext, redis: ArqRedis) -> bool:
+async def _posted_today(redis: ArqRedis, day: str) -> set[str]:
+    members = await cast(
+        "Awaitable[set[bytes]]", redis.smembers(posted_prayers_key(day))
+    )
+    return {m.decode() if isinstance(m, bytes) else str(m) for m in members}
+
+
+async def pick_postable_prayer(
+    context: WorkerContext, redis: ArqRedis, day: str
+) -> tuple[Prayer, str] | None:
+    already = await _posted_today(redis, day)
+    service = PrayerService(context.pocketbase, redis)
+    for _ in range(PICK_TRIES):
+        try:
+            prayer = await service.random_prayer()
+        except NotFoundError:
+            return None
+        if prayer.id in already:
+            continue
+        text = compose_post(prayer)
+        if text is None:
+            continue
+        return prayer, text
+    return None
+
+
+async def publish_prayer(
+    context: WorkerContext, redis: ArqRedis, prayer: Prayer, text: str
+) -> bool:
+    """Return True if the post was committed to X (mark the slot), False to retry."""
     settings = context.settings
-    if not settings.x_enabled:
-        logger.info("x_disabled skipping")
-        return False
-
-    day = _today()
-    if await redis.get(posted_key(day)) is not None:
-        logger.info("x_already_posted day=%s", day)
-        return False
-
-    try:
-        prayer = await DailyService(context.pocketbase, redis).get_daily()
-    except NotFoundError:
-        logger.warning("x_no_prayer_available")
-        return False
-
-    text = compose_post(prayer)
-    if text is None:
-        logger.warning("x_prayer_too_long id=%s len=%d", prayer.id, len(prayer.text))
-        await _alert(
-            context,
-            f"دعاء اليوم أطول من {MAX_POST_LENGTH} حرفًا، فلم يُنشر. المعرّف: {prayer.id}",
-        )
-        return False
 
     if settings.x_dry_run:
-        logger.info("x_dry_run text=%r", text)
-        return False
+        logger.info("x_dry_run prayer=%s text=%r", prayer.id, text)
+        return True
 
     cookies = await load_session(redis, settings.x_session_state)
     if cookies is None:
         logger.error("x_no_session")
-        await _alert(context, "لا توجد جلسة محفوظة. شغّل scripts/build_x_session.py")
+        await alert(context, "لا توجد جلسة محفوظة. شغّل scripts/build_x_session.py")
         return False
 
     try:
@@ -91,25 +106,43 @@ async def post_daily_to_x(context: WorkerContext, redis: ArqRedis) -> bool:
         )
     except SessionExpiredError as error:
         logger.error("x_session_expired")
-        await _alert(context, f"انتهت صلاحية الجلسة: {error}")
+        await alert(context, f"انتهت صلاحية الجلسة: {error}")
         return False
     except WrongAccountError as error:
         logger.error("x_wrong_account %s", error)
-        await _alert(context, f"الجلسة لحساب خاطئ: {error}")
+        await alert(context, f"الجلسة لحساب خاطئ: {error}")
+        return False
+    except PostVerificationError:
+        logger.info("x_submit_rejected prayer=%s", prayer.id)
         return False
     except Exception as error:
         logger.exception("x_post_failed")
-        await _alert(context, f"فشل النشر: {type(error).__name__}: {error}")
+        await alert(context, f"فشل النشر: {type(error).__name__}: {error}")
         return False
 
     await save_session(redis, result.cookies)
-
     if not result.verified:
-        logger.error("x_post_unverified id=%s", prayer.id)
-        await _alert(context, "أُرسل المنشور لكن تعذّر التأكد من ظهوره. راجع الحساب.")
-        return False
-
-    await redis.set(posted_key(day), prayer.id, ex=_POSTED_TTL_SECONDS)
-    await redis.set(X_LAST_POST, f"{day}:{prayer.id}")
-    logger.info("x_posted day=%s prayer=%s", day, prayer.id)
+        logger.warning("x_post_unverified prayer=%s", prayer.id)
+        await alert(context, "أُرسل المنشور لكن تعذّر التأكد من ظهوره. راجع الحساب.")
     return True
+
+
+async def post_one_now(context: WorkerContext, redis: ArqRedis) -> bool:
+    """Post a single random prayer immediately, ignoring the schedule. For
+    manual testing via scripts/post_daily_to_x.py."""
+    if not context.settings.x_enabled:
+        logger.info("x_disabled skipping")
+        return False
+    day = today()
+    picked = await pick_postable_prayer(context, redis, day)
+    if picked is None:
+        logger.warning("x_no_postable_prayer")
+        return False
+    prayer, text = picked
+    committed = await publish_prayer(context, redis, prayer, text)
+    if committed:
+        await cast(
+            "Awaitable[int]", redis.sadd(posted_prayers_key(day), prayer.id)
+        )
+        logger.info("x_posted_manual prayer=%s", prayer.id)
+    return committed

--- a/apps/api/src/x_worker.py
+++ b/apps/api/src/x_worker.py
@@ -5,7 +5,7 @@ import httpx
 from arq import ArqRedis, cron
 
 from src.features.daily.keys import MECCA_TIMEZONE
-from src.features.x.service import post_daily_to_x
+from src.features.x.schedule import dispatch_posts
 from src.shared.ai.client import create_ai_client
 from src.shared.config.settings import get_settings
 from src.shared.logging.setup import configure_logging, get_logger
@@ -47,19 +47,19 @@ async def shutdown(ctx: dict[Any, Any]) -> None:
     logger.info("x_worker_shutdown")
 
 
-async def post_daily(ctx: dict[Any, Any]) -> None:
+async def dispatch(ctx: dict[Any, Any]) -> None:
     context = get_worker_context(ctx)
     redis: ArqRedis = ctx["redis"]
     try:
-        await post_daily_to_x(context, redis)
+        await dispatch_posts(context, redis)
     except Exception:
-        logger.exception("x_daily_post_crashed")
+        logger.exception("x_dispatch_crashed")
 
 
 class WorkerSettings:
     queue_name = "ad3oni:x:queue"
     functions: list[Any] = []
-    cron_jobs = [cron(post_daily, hour=8, minute=0, run_at_startup=False)]
+    cron_jobs = [cron(dispatch, minute=set(range(60)), second=15, run_at_startup=False)]
     timezone = ZoneInfo(MECCA_TIMEZONE)
     on_startup = startup
     on_shutdown = shutdown

--- a/apps/api/tests/test_x_schedule.py
+++ b/apps/api/tests/test_x_schedule.py
@@ -1,0 +1,37 @@
+from src.features.x.keys import GRACE_MINUTES, POST_WINDOWS
+from src.features.x.schedule import is_due, make_plan
+
+
+def test_make_plan_has_one_time_per_window() -> None:
+    plan = make_plan()
+    assert len(plan) == len(POST_WINDOWS)
+
+
+def test_make_plan_times_fall_inside_their_windows() -> None:
+    for _ in range(50):
+        plan = make_plan()
+        for (start, end), stamp in zip(POST_WINDOWS, plan, strict=True):
+            minutes = int(stamp[:2]) * 60 + int(stamp[3:])
+            assert start * 60 <= minutes < end * 60
+
+
+def test_make_plan_times_are_ordered_and_spread() -> None:
+    plan = make_plan()
+    as_minutes = [int(t[:2]) * 60 + int(t[3:]) for t in plan]
+    assert as_minutes == sorted(as_minutes)
+
+
+def test_is_due_at_exact_target() -> None:
+    assert is_due(7 * 60 + 30, "07:30") is True
+
+
+def test_is_due_within_grace_window() -> None:
+    assert is_due(7 * 60 + 30 + GRACE_MINUTES, "07:30") is True
+
+
+def test_is_not_due_before_target() -> None:
+    assert is_due(7 * 60 + 29, "07:30") is False
+
+
+def test_is_not_due_after_grace() -> None:
+    assert is_due(7 * 60 + 30 + GRACE_MINUTES + 1, "07:30") is False

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.2.6"
+version = "0.2.7"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Replaces the single fixed 08:00 X post with **three per day at randomized times** — a random minute inside each of three spread windows (morning 05-09, afternoon 12-16, evening 18-22, Mecca). Varied times also read far more human than an exact-second daily post, which helps the account stay unremarkable.

## How

- schedule.py builds a daily plan of three times, stored in Redis so it is stable across the minute-tick, and dispatches due slots. Reuses the proven Discord-scheduler minute-tick pattern.
- Each slot posts a distinct random prayer, skipping any already posted today or over 280 chars.
- At-most-once per slot: publish never raises once the post is submitted, so a verify/cookie hiccup after the send cannot make the dispatcher retry and double-post. A raise means nothing was sent, so retrying (with a different prayer, e.g. after a duplicate-text rejection) is safe.
- Per-slot dedup key plus a short grace window let a briefly-failed slot retry next tick without bunching.

The worker cron moves from a fixed 08:00 job to a minute tick that only acts when a slot is due, so the browser still launches just three times a day.

## Verification

ruff, mypy (109 files), 88 tests (7 new for plan structure + due logic). Scheduling exercised on the server in dry-run before enabling.

Generated with Claude Code.
