### PR TITLE
chore(api): sync uv.lock project version to 0.3.0

### DIFF
--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.2.7"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Housekeeping: the version bumps since 0.2.4 updated pyproject but not the lock's project version line. No dependency change. uv sync --frozen already passed regardless (it audits deps, not the version).