### PR TITLE
feat(api): tweet the prayer text only

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi==0.136.3",

--- a/apps/api/src/features/x/service.py
+++ b/apps/api/src/features/x/service.py
@@ -30,13 +30,10 @@ logger = get_logger("api.x.service")
 
 
 def compose_post(prayer: Prayer) -> str | None:
+    """The tweet is the du'a and nothing else: no source, type, or attribution."""
     text = prayer.text.strip()
     if len(text) > MAX_POST_LENGTH:
         return None
-    if prayer.source:
-        with_source = f"{text}\n\n{prayer.source.strip()}"
-        if len(with_source) <= MAX_POST_LENGTH:
-            return with_source
     return text
 
 

--- a/apps/api/tests/test_x.py
+++ b/apps/api/tests/test_x.py
@@ -39,16 +39,16 @@ class FakeRedis:
         self.values[key] = value
 
 
-def test_compose_appends_source_when_it_fits() -> None:
+def test_compose_never_appends_the_source() -> None:
     post = compose_post(_prayer("اللهم اغفر لي", "صحيح مسلم"))
-    assert post == "اللهم اغفر لي\n\nصحيح مسلم"
+    assert post == "اللهم اغفر لي"
+    assert "صحيح مسلم" not in (post or "")
 
 
-def test_compose_drops_source_when_it_would_overflow() -> None:
-    text = "ا" * (MAX_POST_LENGTH - 3)
-    post = compose_post(_prayer(text, "صحيح البخاري"))
-    assert post == text
-    assert len(post or "") <= MAX_POST_LENGTH
+def test_compose_is_only_the_prayer_text_even_with_room_to_spare() -> None:
+    post = compose_post(_prayer("اللهم ارزقني الصبر", "سنن الترمذي"))
+    assert post == "اللهم ارزقني الصبر"
+    assert "\n" not in (post or "")
 
 
 def test_compose_returns_none_when_prayer_itself_is_too_long() -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "0.3.0"
+version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Drops the source/attribution line that was appended to each tweet. The post is now just the du'a text, nothing else.

Tests updated to assert the source is never appended. ruff, mypy (109 files), 88 tests green.

Generated with Claude Code.
